### PR TITLE
🐛 Use existing Trove classifiers in dist metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,10 +19,12 @@ setup(
     packages=find_packages('lib'),
     description="Python bindings for libssh client",
     classifiers=[
-        "Programming Language :: Cython",
         "Development Status :: 2 - Pre-Alpha",
         "License :: OSI Approved :: GNU Lesser General Public License v2 (LGPLv2)",
-        "Topic :: Software Development :: Libraries :: Python Modules :: Security",
-        "Operating System :: Linux:: Mac",
+        "Operating System :: MacOS",
+        "Operating System :: POSIX :: Linux",
+        "Programming Language :: Cython",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+        "Topic :: Security",
     ],
 )


### PR DESCRIPTION
This change gets rid of invalid Trove classifiers in favor of existing
ones. Basically, it untangles these classifiers:

* Operating System :: MacOS
* Operating System :: POSIX :: Linux
* Topic :: Software Development :: Libraries :: Python Modules
* Topic :: Security

Ref: https://pypi.org/classifiers/

Fixes #3

Signed-Off-By: Sviatoslav Sydorenko <webknjaz@redhat.com>