### PR TITLE
Implement building sdist via in-tree PEP517 build backend

### DIFF
--- a/.darglint
+++ b/.darglint
@@ -1,0 +1,2 @@
+[darglint]
+docstring_style=sphinx

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,6 +2,7 @@
 [settings]
 # Should be: 80 - 1
 line_length = 79
+include_trailing_comma = true
 # force_to_top=file1.py,file2.py
 # skip=file3.py,file4.py
 # known_future_library=future,pies

--- a/README.rst
+++ b/README.rst
@@ -43,8 +43,8 @@ Build the extension:
 
     git clone https://github.com/ansible/pylibssh.git
     cd pylibssh
-    pip install -r requirements-build.in
-    LDFLAGS='-lssh' cythonize --inplace 'src/**/*.pyx'
+    pip install tox
+    tox -e build-dists
 
 License
 -------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,57 @@
+[build-system]
+requires = [
+  # Essentials
+  "Cython",  # needed by in-tree build backend `bin/pep517_backend.py`
+  "setuptools>=45",  # needed by in-tree build backend `bin/pep517_backend.py`
+  "wheel",
+
+  # Plugins
+  "setuptools_scm>=1.15",
+  "setuptools_scm_git_archive>=1.0",
+]
+backend-path = ["bin"]  # requires 'Pip>=20' or 'pep517>=0.6.0'
+build-backend = "pep517_backend"
+
+[tool.local.cythonize]
+# This attr can contain multiple globs
+src = ["src/**/*.pyx"]
+
+[tool.local.cythonize.env]
+# Env vars provisioned during cythonize call
+LDFLAGS = "-lssh"
+
+[tool.local.cythonize.flags]
+# This section can contain the following booleans:
+# * annotate — generate annotated HTML page for source files
+# * build — build extension modules using distutils
+# * inplace — build extension modules in place using distutils (implies -b)
+# * force — force recompilation
+# * quiet — be less verbose during compilation
+# * lenient — increase Python compat by ignoring some compile time errors
+# * keep-going — compile as much as possible, ignore compilation failures
+annotate = false
+build = false
+inplace = true
+force = true
+quiet = false
+lenient = false
+keep-going = false
+
+[tool.local.cythonize.kwargs]
+# This section can contain args tha have values:
+# * exclude=PATTERN      exclude certain file patterns from the compilation
+# * parallel=N    run builds in N parallel jobs (default: calculated per system)
+# exclude = "**.py"
+# parallel = 12
+
+[tool.local.cythonize.kwargs.directives]
+# This section can contain compiler directives
+# NAME = "VALUE"
+
+[tool.local.cythonize.kwargs.compile-time-env]
+# This section can contain compile time env vars
+# NAME = "VALUE"
+
+[tool.local.cythonize.kwargs.options]
+# This section can contain cythonize options
+# NAME = "VALUE"

--- a/tox.ini
+++ b/tox.ini
@@ -24,30 +24,12 @@ usedevelop = false
 # don't install octomachinery itself in this env
 skip_install = true
 deps =
-    Cython
-    pep517 >= 0.5.0
+    pep517 >= 0.6.0
     twine
-passenv =
-    CFLAGS
-    LDFLAGS
-    NPROC
-    PKG_CONFIG_PATH
 setenv =
     PYPI_UPLOAD = true
 commands =
     rm -rfv {toxinidir}/dist/
-    # cythonize
-    # `--build` instead of `--inplace` creates `pylibsshext/` dir
-    # with `*.so` files in it instead of moving them next
-    # to `*.pyx` sources
-    {envpython} -c 'from Cython.Build.Cythonize import main; main()' \
-      --3str \
-      --inplace \
-      -j {env:NPROC:12} \
-      src/**/*.pyx
-    # Getting the following error
-    # python: No code object available for setup
-    # is caused by importing a cext via `python -m`
     {envpython} -m pep517.build \
       --source \
       --binary \

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ skip_install = true
 deps =
     Cython
     pep517 >= 0.5.0
+    twine
 passenv =
     CFLAGS
     LDFLAGS
@@ -52,7 +53,10 @@ commands =
       --binary \
       --out-dir {toxinidir}/dist/ \
       {toxinidir}
+    ls -alh {toxinidir}/dist/
+    twine check {toxinidir}/dist/*
 whitelist_externals =
+    ls
     rm
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ commands =
     # `--build` instead of `--inplace` creates `pylibsshext/` dir
     # with `*.so` files in it instead of moving them next
     # to `*.pyx` sources
-    python -c 'from Cython.Build.Cythonize import main; main()' \
+    {envpython} -c 'from Cython.Build.Cythonize import main; main()' \
       --3str \
       --inplace \
       -j {env:NPROC:12} \


### PR DESCRIPTION
This change integrates an in-tree PEP 517 build backend
into build-system specified in `pyproject.toml` (PEP 518).

It also adjusts tox config and recommendations in README.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
https://www.python.org/dev/peps/pep-0517/#in-tree-build-backends