### PR TITLE
Improve PEP517 in-tree backend

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -49,6 +49,9 @@ max-line-length = 160
 
 # Allow certain violations in certain files:
 per-file-ignores =
+  # in-tree PEP517 build backend nees a lot of legit `noqa`s
+  bin/pep517_backend.py: WPS402
+
   # Exclude errors that don't make sense for Cython
   src/pylibsshext/*.pyx: E225,E227,E999
 

--- a/bin/pep517_backend.py
+++ b/bin/pep517_backend.py
@@ -113,7 +113,7 @@ def _emit_opt_pairs(opt_pair):
         sub_pairs = ((flag_value, ), )
 
     for pair in sub_pairs:  # noqa: WPS526
-        yield '='.join(map(str, (flag_opt, *pair)))
+        yield '='.join(map(str, (flag_opt, ) + pair))
 
 
 def pre_build_cython(orig_func):  # noqa: WPS210
@@ -140,6 +140,9 @@ def pre_build_cython(orig_func):  # noqa: WPS210
             map(_emit_opt_pairs, config['kwargs'].items()),
         ))
         cythonize_args = cli_flags + [py_ver_arg] + cli_kwargs + config['src']
+        if sys.version_info[0] == 2:  # cythonize wants str() internally
+            # turn Unicode into native Python 2 `str`:
+            cythonize_args = [arg.encode() for arg in cythonize_args]
         with patched_env(config['env']):
             cythonize_cli_cmd(cythonize_args)
         return orig_func(*args, **kwargs)

--- a/bin/pep517_backend.py
+++ b/bin/pep517_backend.py
@@ -20,6 +20,7 @@ from setuptools.build_meta import (
 # noqa: I001, I004, E800  # flake8-isort is drunk
 import toml  # noqa: I001
 from Cython.Build.Cythonize import main as cythonize_cli_cmd  # noqa: I001
+from expandvars import expandvars  # noqa: I001
 
 __all__ = (  # noqa: WPS317, WPS410
     'build_sdist', 'build_wheel', 'get_requires_for_build_sdist',
@@ -96,7 +97,8 @@ def patched_env(env):
     :yields: None
     """
     orig_env = os.environ.copy()
-    os.environ.update(env)
+    expanded_env = {name: expandvars(var_val) for name, var_val in env.items()}
+    os.environ.update(expanded_env)
     try:  # noqa: WPS501
         yield
     finally:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ requires = [
   "Cython",  # needed by in-tree build backend `bin/pep517_backend.py`
   "setuptools>=45",  # needed by in-tree build backend `bin/pep517_backend.py`
   "wheel",
+  "expandvars",  # needed by in-tree build backend for env vars interpolation
 
   # Plugins
   "setuptools_scm>=1.15",
@@ -18,7 +19,7 @@ src = ["src/**/*.pyx"]
 
 [tool.local.cythonize.env]
 # Env vars provisioned during cythonize call
-LDFLAGS = "-lssh"
+LDFLAGS = "-lssh ${LDFLAGS}"
 
 [tool.local.cythonize.flags]
 # This section can contain the following booleans:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,0 @@
-# -*- coding: utf-8 -*-
-
-"""Dist metadata setup."""
-
-from setuptools import setup
-
-__name__ == '__main__' and setup()  # noqa: WPS428


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This change drops `setup.py` forgotten in the tree during the revert. It also ensures that specifically platlib wheels are emitted. And finally, it implements
env vars interpolation in `pyproject.toml` settings.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Feature Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
N/A