### PR TITLE
Inject tests matrix between build and publish in GHA

### DIFF
--- a/.github/workflows/build-test-n-publish.yml
+++ b/.github/workflows/build-test-n-publish.yml
@@ -174,7 +174,7 @@ jobs:
         ${{ steps.install-python.outputs.binary }}
         -m pytest
     - name: Store the binary wheel
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       with:
         name: >-
           dist-wheel-${{ runner.os }}-python${{ matrix.python-version }}
@@ -207,7 +207,7 @@ jobs:
     - name: Build dists and verify wheel metadata
       run: python -m tox -p auto --parallel-live -vvvv
     - name: Store the source distribution
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       with:
         name: dist-wheels-manylinux
         path: dist
@@ -240,7 +240,7 @@ jobs:
     - name: Build sdist and verify metadata
       run: python -m tox -p auto --parallel-live -vvvv
     - name: Store the source distribution
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       with:
         name: dist-src
         path: dist
@@ -255,7 +255,7 @@ jobs:
     steps:
     - name: >-
         Download all the dists
-      uses: actions/download-artifact@v2-preview  # FIXME: switch to v2
+      uses: actions/download-artifact@v2
       with:
         path: .github/workflows/.tmp/artifacts
     - name: Copy all the dists into the dist/ folder
@@ -267,7 +267,7 @@ jobs:
     - name: >-
         Store the whole distributions
         matrix as a combined artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       with:
         name: all-the-dists
         path: dist
@@ -299,7 +299,7 @@ jobs:
     - name: Pre-populate tox env
       run: python -m tox -p auto --parallel-live -vvvv --notest
     - name: Download all the dists
-      uses: actions/download-artifact@v1  # FIXME: switch to v2
+      uses: actions/download-artifact@v2
       with:
         name: all-the-dists
         path: dist/

--- a/.github/workflows/build-test-n-publish.yml
+++ b/.github/workflows/build-test-n-publish.yml
@@ -272,10 +272,75 @@ jobs:
         name: all-the-dists
         path: dist
 
+  test-matrix:
+    name: >-
+      Test 🐍
+      ${{ matrix.python-version }}
+      ${{ matrix.runner-vm-os }}
+      ${{ matrix.dist-type }} dists
+    needs:
+    - all-the-dists-combo
+    runs-on: ${{ matrix.runner-vm-os }}-latest
+    strategy:
+      matrix:
+        python-version:
+        - 3.8
+        - 2.7
+        - 3.7
+        - 3.6
+        - 3.5
+        runner-vm-os:
+        - ubuntu
+        - macos
+        dist-type:
+        - binary
+        - source
+        exclude:
+        - dist-type: source
+          runner-vm-os: ubuntu
+
+    env:
+      PY_COLORS: 1
+      TOXENV: test-${{ matrix.dist-type }}-dists
+      TOX_PARALLEL_NO_SPINNER: 1
+
+    steps:
+    - name: Install libssh and openssl headers on Linux
+      if: >-
+        matrix.dist-type == 'source' &&
+        runner.os == 'Linux'
+      run: sudo apt update && sudo apt install libssh-dev libssl-dev build-essential
+    - name: Install libssh and openssl headers on macOS
+      if: >-
+        matrix.dist-type == 'source' &&
+        runner.os == 'macOS'
+      run: brew install libssh
+    - name: Switch 🐍 to v${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install tox
+      run: >-
+        python -m
+        pip install
+        --user
+        tox
+    - name: Check out src from Git
+      uses: actions/checkout@v2
+    - name: Download all the dists
+      uses: actions/download-artifact@v2
+      with:
+        name: all-the-dists
+        path: dist/
+    - name: Pre-populate tox env
+      run: python -m tox -p auto --parallel-live -vvvv --notest
+    - name: Run tests
+      run: python -m tox -p auto --parallel-live -vvvv
+
   deploy:
     name: Publish 🐍📦 (currently only lists stuff)
     needs:
-    - all-the-dists-combo
+    - test-matrix
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/build-test-n-publish.yml
+++ b/.github/workflows/build-test-n-publish.yml
@@ -1,4 +1,4 @@
-name: 🏗 Python 📦 distributions
+name: 🏗 📦 & test & publish
 
 on:
   push:

--- a/.gitignore
+++ b/.gitignore
@@ -391,4 +391,5 @@ $RECYCLE.BIN/
 
 # End of https://www.gitignore.io/api/git,linux,pydev,python,windows,pycharm+all,jupyternotebook,vim,webstorm,emacs,dotenv
 
-.github/workflows/.tmp
+/.github/workflows/.tmp
+/.test-results

--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,53 @@ isolated_build = true
 usedevelop = false
 deps =
     pytest
+    pytest-cov
+    pytest-xdist
 commands =
     {envpython} -m pytest {posargs:}
+
+[testenv:test-binary-dists]
+skip_install = true
+commands_pre =
+    # WARNING: Be sure to keep the `--no-index` arg.
+    # WARNING: Otherwise, pip may prefer PyPI over
+    # WARNING: the local dists dir.
+    {envpython} -m pip install \
+      --only-binary ansible-pylibssh \
+      -f {env:PEP517_OUT_DIR} \
+      --no-index \
+      ansible-pylibssh
+setenv =
+    {[dists]setenv}
+
+[testenv:test-source-dists]
+skip_install = true
+commands_pre =
+    # Pre-fetch sdist build deps:
+    {envpython} -m pip download \
+      --prefer-binary \
+      --only-binary Cython \
+      --only-binary setuptools \
+      --only-binary setuptools-scm \
+      --only-binary setuptools-scm-git-archive \
+      --only-binary toml \
+      --only-binary wheel \
+      --dest {toxinidir}/.github/workflows/.tmp/deps \
+      Cython expandvars setuptools \
+      setuptools-scm setuptools-scm-git-archive \
+      toml wheel
+
+    # WARNING: Be sure to keep the `--no-index` arg.
+    # WARNING: Otherwise, pip may prefer PyPI over
+    # WARNING: the local dists dir.
+    {envpython} -m pip install \
+      --no-binary ansible-pylibssh \
+      -f {env:PEP517_OUT_DIR} \
+      -f {toxinidir}/.github/workflows/.tmp/deps \
+      --no-index \
+      ansible-pylibssh
+setenv =
+    {[dists]setenv}
 
 [dists]
 setenv =


### PR DESCRIPTION
This adds testing of some dists that are built and stored as artifacts, namely:
- binary dists under Ubuntu and macOS
- source dist under macOS

P.S. This change excludes testing sdist under Ubuntu because we still have to figure out the build deps/options there.