### PR TITLE
Refactor `read_bulk_response`

### DIFF
--- a/src/pylibsshext/channel.pyx
+++ b/src/pylibsshext/channel.pyx
@@ -126,11 +126,15 @@ cdef class Channel:
                 if not data:
                     if timeout:
                         time.sleep(timeout)
-                else:
-                    recv_buff.write(data)
-                    offset = recv_buff.tell() - size if recv_buff.tell() > size else 0
-                    recv_buff.seek(offset)
-                    response += recv_buff.read()
+                    continue
+
+                recv_buff.write(data)
+                offset = recv_buff.tell() - size
+                if offset < 0:
+                    offset = 0
+
+                recv_buff.seek(offset)
+                response += recv_buff.read()
 
         return response
 

--- a/src/pylibsshext/channel.pyx
+++ b/src/pylibsshext/channel.pyx
@@ -113,22 +113,21 @@ cdef class Channel:
         return self.write(data)
 
     def read_bulk_response(self, size=1024, stderr=0, timeout=0.001, retry=5):
-        recv = BytesIO()
         response = b""
-        while retry:
-            data = self.read_nonblocking(size=size, stderr=stderr)
-            if not data:
-                if timeout:
-                    time.sleep(timeout)
-            else:
-                recv.write(data)
-                offset = recv.tell() - size if recv.tell() > size else 0
-                recv.seek(offset)
-                response += recv.read()
+        with BytesIO() as recv_buff:
+            while retry:
+                data = self.read_nonblocking(size=size, stderr=stderr)
+                if not data:
+                    if timeout:
+                        time.sleep(timeout)
+                else:
+                    recv_buff.write(data)
+                    offset = recv_buff.tell() - size if recv_buff.tell() > size else 0
+                    recv_buff.seek(offset)
+                    response += recv_buff.read()
 
-            retry = retry - 1
+                retry = retry - 1
 
-        recv.close()
         return response
 
     def exec_command(self, command):

--- a/src/pylibsshext/channel.pyx
+++ b/src/pylibsshext/channel.pyx
@@ -113,9 +113,15 @@ cdef class Channel:
         return self.write(data)
 
     def read_bulk_response(self, size=1024, stderr=0, timeout=0.001, retry=5):
+        if retry <= 0:
+            raise ValueError(
+                'Got arg `retry={arg!r}` but it must be greater than 0'.
+                format(arg=retry),
+            )
+
         response = b""
         with BytesIO() as recv_buff:
-            while retry:
+            for _ in range(retry, 0, -1):
                 data = self.read_nonblocking(size=size, stderr=stderr)
                 if not data:
                     if timeout:
@@ -125,8 +131,6 @@ cdef class Channel:
                     offset = recv_buff.tell() - size if recv_buff.tell() > size else 0
                     recv_buff.seek(offset)
                     response += recv_buff.read()
-
-                retry = retry - 1
 
         return response
 


### PR DESCRIPTION
This change makes `Channel.read_bulk_response` simpler and fixes a bug with an infinite loop with a negative retry arg.