### PR TITLE
Fix session timeout issue

### DIFF
--- a/src/pylibsshext/session.pyx
+++ b/src/pylibsshext/session.pyx
@@ -89,6 +89,7 @@ cdef class Session:
 
     def set_ssh_options(self, key, value):
         cdef unsigned int port_i
+        cdef long timeout_i
 
         key_m = None
         if key in OPTS_DIR_MAP:
@@ -100,6 +101,9 @@ cdef class Session:
         if key == "port":
             port_i = value
             libssh.ssh_options_set(self._libssh_session, OPTS_MAP["port"], &port_i)
+        elif key == "timeout":
+            timeout_i = value
+            libssh.ssh_options_set(self._libssh_session, OPTS_MAP["timeout"], &timeout_i)
         else:
             if isinstance(value, basestring):
                 value = value.encode("utf-8")


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
*  The data type of timeout is expected by ssh_options_set
   is of type long int. Since char was passed for longer timeout
   values it failed setting the right timeout value
*  Explicitly define long int variable for timeout
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
