### PR TITLE
Implement initial `ssh_client_session` fixture

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
   # Non-modifying checks:
   - id: name-tests-test
     files: >-
-      ^tests/.*\.py$
+      ^tests/[^_].*\.py$
   - id: check-added-large-files
   - id: check-byte-order-marker
   - id: check-case-conflict

--- a/src/pylibsshext/includes/libssh.pxd
+++ b/src/pylibsshext/includes/libssh.pxd
@@ -142,7 +142,7 @@ cdef extern from "libssh/libssh.h" nogil:
     int ssh_options_set(ssh_session session, ssh_options_e type, const void *value)
 
     int ssh_get_server_publickey(ssh_session session, ssh_key *key)
-    void ssh_key_free(ssh_key)
+    void ssh_key_free(ssh_key key)
 
     int ssh_get_publickey_hash(const ssh_key key, ssh_publickey_hash_type type, unsigned char **hash, size_t *hlen)
     char *ssh_get_hexa(const unsigned char *what, size_t len)
@@ -158,7 +158,7 @@ cdef extern from "libssh/libssh.h" nogil:
         const char *b64_key, const char *passphrase,
         ssh_auth_callback auth_fn, void *auth_data, ssh_key *pkey)
 
-    int ssh_userauth_publickey(ssh_session session, const char *username, const ssh_key *privkey)
+    int ssh_userauth_publickey(ssh_session session, const char *username, const ssh_key privkey)
     int ssh_userauth_publickey_auto(ssh_session session, const char *username, const char *passphrase)
     int ssh_userauth_password(ssh_session session, const char *username, const char *password)
 

--- a/src/pylibsshext/includes/libssh.pxd
+++ b/src/pylibsshext/includes/libssh.pxd
@@ -151,6 +151,14 @@ cdef extern from "libssh/libssh.h" nogil:
     ssh_keytypes_e ssh_key_type(ssh_key key)
     int ssh_session_update_known_hosts(ssh_session session)
 
+    ctypedef int(*ssh_auth_callback)(
+        const char *prompt, char *buf, size_t len,
+        int echo, int verify, void *userdata)
+    int ssh_pki_import_privkey_base64(
+        const char *b64_key, const char *passphrase,
+        ssh_auth_callback auth_fn, void *auth_data, ssh_key *pkey)
+
+    int ssh_userauth_publickey(ssh_session session, const char *username, const ssh_key *privkey)
     int ssh_userauth_publickey_auto(ssh_session session, const char *username, const char *passphrase)
     int ssh_userauth_password(ssh_session session, const char *username, const char *password)
 

--- a/src/pylibsshext/session.pyx
+++ b/src/pylibsshext/session.pyx
@@ -358,15 +358,18 @@ cdef class Session(object):
             NULL, NULL,
             &_private_key,
         )
+
         rc = libssh.ssh_userauth_publickey(
-            self._libssh_session, NULL, &_private_key,
+            self._libssh_session, NULL, _private_key,
         )
+
         if rc != libssh.SSH_AUTH_SUCCESS:
             raise LibsshSessionException(
                 "Failed to authenticate a specific public key: "
                 "{!s} (RC={!r})".
                 format(self._get_session_error_str(), rc),
             )
+        libssh.ssh_key_free(_private_key)
 
     def authenticate_pubkey(self):
         cdef int rc

--- a/tests/_service_utils.py
+++ b/tests/_service_utils.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+
+"""Test util helpers."""
+
+import contextlib
+import socket
+import sys
+import time
+
+IS_MACOS = sys.platform == 'darwin'
+PY3_PLUS = sys.version_info[0] > 2
+_MACOS_RECONNECT_ATTEMPT_DELAY = 0.02
+_LINUX_RECONNECT_ATTEMPT_DELAY = 0.001
+_DEFAULT_RECONNECT_ATTEMPT_DELAY = (
+    _MACOS_RECONNECT_ATTEMPT_DELAY
+    if IS_MACOS
+    else _LINUX_RECONNECT_ATTEMPT_DELAY
+)
+
+
+@contextlib.contextmanager
+def _socket():
+    sock = socket.socket()
+    try:  # noqa: WPS501
+        yield sock
+    finally:
+        sock.close()
+
+
+def _match_proto_start(sock, b_proto_id):
+    while b_proto_id:
+        buff = sock.recv(len(b_proto_id))
+        if not buff or not b_proto_id.startswith(buff):
+            raise RuntimeError(
+                'The remote service did not send '
+                'expected identifier string',  # noqa: WPS326
+            )
+        b_proto_id = b_proto_id[len(buff):]
+
+
+def wait_for_svc_ready_state(  # noqa: WPS317
+        host, port, protocol_identifier,  # noqa: WPS318
+        max_conn_attempts=10,
+        reconnect_attempt_delay=_DEFAULT_RECONNECT_ATTEMPT_DELAY,
+):
+    """Verify that the serivce is up and running.
+
+    :param host: Hostname.
+    :type host: str
+
+    :param port: Port.
+    :type port: int
+
+    :param protocol_identifier: Protocol start string.
+    :type protocol_identifier: bytes
+
+    :param max_conn_attempts: Number of tries when connecting.
+    :type max_conn_attempts: int
+
+    :param reconnect_attempt_delay: Time to sleep between retries.
+    :type reconnect_attempt_delay: float
+
+    # noqa: DAR401
+    """
+    connection_errors = (ConnectionError if PY3_PLUS else socket.error, )
+
+    for attempt_num in range(1, max_conn_attempts + 1):
+        with _socket() as sock:
+            if attempt_num >= max_conn_attempts:
+                connection_errors = ()
+
+            try:
+                sock.connect((host, port))
+            except connection_errors:
+                time.sleep(reconnect_attempt_delay)
+            else:
+                _match_proto_start(sock, protocol_identifier)
+                break

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -159,11 +159,11 @@ def sshd_addr(free_port_num, ssh_authorized_keys_path, sshd_hostkey_path, sshd_p
         opt, 'Protocol=2',
         opt, 'HostbasedAuthentication=no',
         opt, 'IgnoreUserKnownHosts=yes',
-        opt, 'ListenAddress=127.0.0.1',
+        opt, 'Port={port:d}'.format(port=free_port_num),  # port before addr
+        opt, 'ListenAddress=127.0.0.1',  # addr after port
         opt, 'AuthorizedKeysFile={auth_keys!s}'.format(auth_keys=ssh_authorized_keys_path),
         opt, 'AcceptEnv=LANG LC_*',
         opt, 'Subsystem=sftp internal-sftp',
-        opt, 'Port={port:d}'.format(port=free_port_num),
     )
     proc = subprocess.Popen(cmd)  # , stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     time.sleep(_SSHD_SPAWN_TIME)

--- a/tests/integration/sshd_test.py
+++ b/tests/integration/sshd_test.py
@@ -5,7 +5,7 @@
 MAX_PORT_NUMBER = 65535
 
 
-def test_sshd_addr_fixture_port(sshd_addr):
+def test_sshd_addr_fixture_port(sshd_addr, ssh_client_session):
     """Smoke-test sshd_addr fixture.
 
     # noqa: DAR101


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR attempts to implement a public-private keypair auth in the session
with a specific key that is already present in memory.

The idea is that the caller should be able to feed bytes and an optional password
into the connect method.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

atm the auth attempt gets rejected for the private key that is 100% correct.
