### PR TITLE
Fix sftp file get issue on py2

### DIFF
--- a/src/pylibsshext/sftp.pyx
+++ b/src/pylibsshext/sftp.pyx
@@ -91,13 +91,17 @@ cdef class SFTP:
                 break
             elif file_data < 0:
                 sftp.sftp_close(rf)
-                raise LibsshSFTPException("Opening remote file [%s] for read failed" % remote_file)
+                raise LibsshSFTPException("Reading data from remote file [%s] failed with error [%s]"
+                                          % (remote_file, MSG_MAP.get(self._get_sftp_error_str())))
 
             with open(local_file, 'w+') as f:
-                bytes_wrote = f.write(read_buffer[:file_data].decode("UTF-8"))
-                if file_data != bytes_wrote:
+                bytes_wrote = f.write(read_buffer[:file_data].decode('utf-8'))
+                if bytes_wrote and file_data != bytes_wrote:
                     sftp.sftp_close(rf)
-                    raise LibsshSFTPException("Opening remote file [%s] for read failed" % remote_file)
+                    raise LibsshSFTPException("Number of bytes [%s] read from remote file [%s]"
+                                              " does not match number of bytes [%s] written to local file [%s]"
+                                              " due to error [%s]"
+                                              % (file_data, remote_file, bytes_wrote, local_file, MSG_MAP.get(self._get_sftp_error_str())))
         sftp.sftp_close(rf)
 
     def close(self):

--- a/tests/unit/sftp_test.py
+++ b/tests/unit/sftp_test.py
@@ -2,14 +2,9 @@
 
 """Tests suite for sftp."""
 
-import sys
 import uuid
 
 import pytest
-
-from pylibsshext.errors import LibsshSFTPException
-
-IS_PY2 = sys.version_info[0] == 2
 
 
 @pytest.fixture
@@ -64,11 +59,6 @@ def test_put(dst_path, src_path, sftp_session, transmit_payload):
     assert dst_path.read_bytes() == transmit_payload
 
 
-@pytest.mark.xfail(
-    IS_PY2,
-    raises=LibsshSFTPException,
-    reason='Some fs permissions error.',
-)
 def test_get(dst_path, src_path, sftp_session, transmit_payload):
     """Check that SFTP file download works."""
     sftp_session.get(str(src_path), str(dst_path))


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
*  the file write() method returns None on py2
   is bytes are written to file successfully, whereas
   on py3 it returns total number of bytes written
   to file.
*  Add fix to check for the number of bytes written only
   in the case when write() is not returning None
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
