### PR TITLE
Publish tagged releases in GHA on tag created

### DIFF
--- a/.github/workflows/build-test-n-publish.yml
+++ b/.github/workflows/build-test-n-publish.yml
@@ -1,6 +1,7 @@
 name: 🏗 📦 & test & publish
 
 on:
+  create:  # branch or tag created, need to filter on publish
   push:
   pull_request:
 
@@ -32,9 +33,9 @@ jobs:
         print('::set-output name=is_untagged_devel::true')
     - name: Mark the build as tagged
       id: tagged_check
-      if: >-
-        github.event_name == 'push' &&
-        startsWith(github.ref, 'refs/tags')
+      if: >-  # "create" workflows run separately from "push" & "pull_request"
+        github.event_name == 'create' &&
+        github.event.ref_type == 'tag'
       run: >-
         print('::set-output name=is_tagged::true')
     - name: Enable profiling of the build


### PR DESCRIPTION
This commit changes the trigger for publishing dists to PyPI.
The UX stays the same (push a Git tag) but the implementation
is more robust since it excludes the possibility of a race
condition of event triggers.

Resolves #69