### PR TITLE
Fix shell response buffer issue

### DIFF
--- a/src/pylibsshext/channel.pyx
+++ b/src/pylibsshext/channel.pyx
@@ -112,7 +112,7 @@ cdef class Channel:
     def sendall(self, data):
         return self.write(data)
 
-    def read_bulk_response(self, size=1024, stderr=0, timeout=0.001, retry=5):
+    def read_bulk_response(self, stderr=0, timeout=0.001, retry=5):
         if retry <= 0:
             raise ValueError(
                 'Got arg `retry={arg!r}` but it must be greater than 0'.
@@ -122,20 +122,14 @@ cdef class Channel:
         response = b""
         with BytesIO() as recv_buff:
             for _ in range(retry, 0, -1):
-                data = self.read_nonblocking(size=size, stderr=stderr)
+                data = self.read_nonblocking(size=1024, stderr=stderr)
                 if not data:
                     if timeout:
                         time.sleep(timeout)
                     continue
 
                 recv_buff.write(data)
-                offset = recv_buff.tell() - size
-                if offset < 0:
-                    offset = 0
-
-                recv_buff.seek(offset)
-                response += recv_buff.read()
-
+            response = recv_buff.getvalue()
         return response
 
     def exec_command(self, command):

--- a/tests/unit/channel_test.py
+++ b/tests/unit/channel_test.py
@@ -2,7 +2,11 @@
 
 """Tests suite for channel."""
 
+import time
+
 import pytest
+
+COMMAND_TIMEOUT = 30
 
 
 @pytest.fixture
@@ -45,3 +49,19 @@ def test_channel_exit_status(ssh_channel):
     """Test retrieving a channel exit status upon close."""
     ssh_channel.close()
     assert ssh_channel.get_channel_exit_status() == -1
+
+
+def test_read_bulk_response(ssh_client_session):
+    """Test getting the output of a remotely executed command."""
+    ssh_shell = ssh_client_session.invoke_shell()
+    ssh_shell.sendall(b'echo -n Hello World')
+    response = b''
+    timeout = 2
+    while b'Hello World' not in response:
+        response += ssh_shell.read_bulk_response()
+        time.sleep(timeout)
+        timeout += 2
+        if timeout == COMMAND_TIMEOUT:
+            break
+
+    assert b'Hello World' in response  # noqa: WPS302


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
*    Read the entire content of the buffer using getvalue()
     to avoid re-reading of the buffer.
*  Add unit test
*  Fix CI issue
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Fixes issue described here https://github.com/ansible-collections/ansible.netcommon/pull/30#issuecomment-654341366
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
