### PR TITLE
Add docs community pages and GH special files

### DIFF
--- a/.github/CODE_OF_CONDUCT.rst
+++ b/.github/CODE_OF_CONDUCT.rst
@@ -1,0 +1,9 @@
+=========================
+Community Code of Conduct
+=========================
+
+Please see the official `Ansible Community Code of Conduct`_.
+
+.. _Ansible Community Code of Conduct:
+   https://docs.ansible.com/ansible/latest/community
+   /code_of_conduct.html

--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -1,0 +1,41 @@
+================================
+Contributing to ansible-pylibssh
+================================
+
+.. attention::
+
+   ansible-pylibssh project exists solely to allow Ansible connection
+   plugins to use libssh_ SSH implementation by importing it in
+   Python-land. At the moment we don't accept any contributions, nor
+   feature requests that are unrelated to this goal.
+
+   But if you want to contribute a bug fix or send a pull-request
+   improving our CI, testing and packaging, we will gladly review it.
+
+
+In order to contribute, you'll need to:
+
+  1. Fork the repository.
+
+  2. Create a branch, push your changes there.
+
+  3. Send it to us as a PR.
+
+  4. Iterate on your PR, incorporating the requested improvements
+     and participating in the discussions.
+
+Prerequisites:
+
+  1. Have libssh_.
+
+  2. Use tox_ to build the C-extension, docs and run the tests.
+
+  3. Before sending a PR, make sure that the linters pass:
+
+     .. code-block:: shell-session
+
+        $ tox -e lint
+
+
+.. _libssh: https://www.libssh.org
+.. _tox: https://tox.readthedocs.io

--- a/.github/SECURITY.rst
+++ b/.github/SECURITY.rst
@@ -1,0 +1,33 @@
+===============
+Security Policy
+===============
+
+------------------
+Supported Versions
+------------------
+
+Ansible applies security fixes according to the 3-versions-back support
+policy. Please find more information in `our docs <Ansible release and
+maintenance_>`_.
+
+.. _Ansible release and maintenance:
+   https://docs.ansible.com/ansible/devel/reference_appendices
+   /release_and_maintenance.html#release-status
+
+-------------------------
+Reporting a Vulnerability
+-------------------------
+
+.. attention::
+
+   **⚠️ Please do not file public GitHub issues for security
+   vulnerabilities as they are open for everyone to see! ⚠️**
+
+We encourage responsible disclosure practices for security
+vulnerabilities. Please read `our policies for reporting bugs <Ansible
+policies for reporting bugs_>`_ if you want to report a security issue
+that might affect Ansible.
+
+.. _Ansible policies for reporting bugs:
+   https://docs.ansible.com/ansible/devel/community
+   /reporting_bugs_and_features.html#reporting-a-bug

--- a/README.rst
+++ b/README.rst
@@ -26,8 +26,12 @@
    :target: https://docs.ansible.com/ansible/latest/community/code_of_conduct.html
    :alt: Ansible Code of Conduct
 
+.. DO-NOT-REMOVE-docs-badges-END
+
 pylibssh: Python bindings to client functionality of libssh specific to Ansible use case
 ========================================================================================
+
+.. DO-NOT-REMOVE-docs-intro-START
 
 Nightlies @ Dumb PyPI @ GitHub Pages
 ------------------------------------
@@ -73,7 +77,7 @@ are set properly:
     $ pip install tox
     $ tox -e build-dists
 
-`manylinux`-compatible wheels:
+``manylinux``-compatible wheels:
 
 .. code-block:: shell-session
 

--- a/README.rst
+++ b/README.rst
@@ -38,12 +38,12 @@ by `dumb-pypi <https://pypi.org/project/dumb-pypi/>`_.
 
 The web view is @ https://ansible.github.io/pylibssh/.
 
-.. code-block:: shell
+.. code-block:: shell-session
 
-    pip install \
-      --extra-index-url=https://ansible.github.io/pylibssh/simple/ \
-      --pre \
-      ansible-pylibssh
+    $ pip install \
+        --extra-index-url=https://ansible.github.io/pylibssh/simple/ \
+        --pre \
+        ansible-pylibssh
 
 
 Requirements
@@ -66,27 +66,27 @@ In the local env, assumes there's a libssh shared library
 on the system, build toolchain is present and env vars
 are set properly:
 
-.. code-block:: shell
+.. code-block:: shell-session
 
-    git clone https://github.com/ansible/pylibssh.git
-    cd pylibssh
-    pip install tox
-    tox -e build-dists
+    $ git clone https://github.com/ansible/pylibssh.git
+    $ cd pylibssh
+    $ pip install tox
+    $ tox -e build-dists
 
 `manylinux`-compatible wheels:
 
-.. code-block:: shell
+.. code-block:: shell-session
 
-    git clone https://github.com/ansible/pylibssh.git
-    cd pylibssh
-    pip install tox
-    tox -e build-dists-manylinux  # with Docker
+    $ git clone https://github.com/ansible/pylibssh.git
+    $ cd pylibssh
+    $ pip install tox
+    $ tox -e build-dists-manylinux  # with Docker
 
     # or with Podman
-    DOCKER_EXECUTABLE=podman tox -e build-dists-manylinux
+    $ DOCKER_EXECUTABLE=podman tox -e build-dists-manylinux
 
     # to enable shell script debug mode use
-    tox -e build-dists-manylinux -- -e DEBUG=1
+    $ tox -e build-dists-manylinux -- -e DEBUG=1
 
 License
 -------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,6 +38,10 @@ version = '.'.join(
 # The full version, including alpha/beta/rc tags
 release = get_version(root=(Path(__file__).parents[1]).resolve())
 
+rst_epilog = f"""
+.. |project| replace:: {project}
+"""  # pylint: disable=invalid-name
+
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/contributing/code_of_conduct.rst
+++ b/docs/contributing/code_of_conduct.rst
@@ -1,0 +1,1 @@
+.. include:: ../../.github/CODE_OF_CONDUCT.rst

--- a/docs/contributing/guidelines.rst
+++ b/docs/contributing/guidelines.rst
@@ -1,0 +1,1 @@
+.. include:: ../../.github/CONTRIBUTING.rst

--- a/docs/contributing/security.rst
+++ b/docs/contributing/security.rst
@@ -1,0 +1,1 @@
+.. include:: ../../.github/SECURITY.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,7 @@ Welcome to ansible-pylibssh's documentation!
 .. toctree::
    :caption: Contributing
 
+   contributing/code_of_conduct.rst
    contributing/security.rst
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,11 @@ Welcome to ansible-pylibssh's documentation!
    :maxdepth: 2
    :caption: Contents:
 
+.. toctree::
+   :caption: Contributing
+
+   contributing/security.rst
+
 
 
 Indices and tables

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,12 @@
 Welcome to |project|'s documentation!
 =====================================
 
+.. include:: ../README.rst
+   :end-before: DO-NOT-REMOVE-docs-badges-END
+
+.. include:: ../README.rst
+   :start-after: DO-NOT-REMOVE-docs-intro-START
+
 .. toctree::
    :maxdepth: 2
    :caption: Contents:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@ Welcome to ansible-pylibssh's documentation!
    :caption: Contributing
 
    contributing/code_of_conduct.rst
+   contributing/guidelines.rst
    contributing/security.rst
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,8 +3,8 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to ansible-pylibssh's documentation!
-============================================
+Welcome to |project|'s documentation!
+=====================================
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
This change includes CODE_OF_CONDUCT, CONTRIBUTING, and SECURITY files.
They will show up on GitHub UI as well as on RTD.
It also embeds README into the Sphinx index.