### PR TITLE
📝 Add a `:user:` role to Sphinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,6 +22,7 @@ github_repo_org = 'ansible'
 github_repo_name = 'pylibssh'
 github_repo_slug = f'{github_repo_org}/{github_repo_name}'
 github_repo_url = f'{github_url}/{github_repo_slug}'
+github_sponsors_url = f'{github_url}/sponsors'
 
 project = f'{github_repo_org}-{github_repo_name}'
 author = 'Ansible, Inc.'
@@ -124,6 +125,7 @@ extlinks = {
     'pr': (f'{github_repo_url}/pull/%s', 'PR #'),  # noqa: WPS323
     'commit': (f'{github_repo_url}/commit/%s', ''),  # noqa: WPS323
     'gh': (f'{github_url}/%s', 'GitHub: '),  # noqa: WPS323
+    'user': (f'{github_sponsors_url}/%s', '@'),  # noqa: WPS323
 }
 
 # -- Options for intersphinx extension ---------------------------------------


### PR DESCRIPTION
This change adds a role that links to the GitHub user Sponsors
page. If that page is not set up, it'll redirect to the GitHub user
profile page instead.