### PR TITLE
📝 Connect Cython docs website via InterSphinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -130,6 +130,7 @@ extlinks = {
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
+    'cython': ('https://cython.readthedocs.io/en/latest', None),
     'python': ('https://docs.python.org/3', None),
     'python2': ('https://docs.python.org/2', None),
 }


### PR DESCRIPTION
To find linkable targets there, use the following command:
```console
$ python -m sphinx.ext.intersphinx https://cython.readthedocs.io/en/latest/objects.inv
```
