### PR TITLE
Refactor sphinx RST parsing in towncrier extension

### DIFF
--- a/docs/changelog-fragments/119.misc.rst
+++ b/docs/changelog-fragments/119.misc.rst
@@ -1,0 +1,1 @@
+Refactor sphinx RST parsing in towncrier extension -- by :user:`ewjoachim`


### PR DESCRIPTION
##### SUMMARY
Following an [exchange on Twitter](https://twitter.com/Ewjoachim/status/1289323468270395393), I wanted to explore why the `nested_parse_with_titles` Sphinx function (which is [documented](https://www.sphinx-doc.org/en/master/extdev/markupapi.html?highlight=nested_parse_with_titles#parsing-directive-content-as-rest)) wasn't used instead of interacting directly with the state machine.

The answer is "It's longer and not particularly more readable". Still, I'm posting this PR and letting you decide what you want to do with it.

I didn't remember that it was this convoluted. But I managed to make it work 🎉 

<img width="893" alt="Capture d’écran 2020-08-01 à 02 14 34" src="https://user-images.githubusercontent.com/1457576/89089266-c57ec580-d39c-11ea-95a9-edb0bfd0b3b7.png">

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Refactor Pull Request :)

##### ADDITIONAL INFORMATION
As usually with docutils, part of the solution came from a [random Google Groups](https://groups.google.com/forum/#!topic/sphinx-dev/IXQdvsFi1qM) answer which I'm linking here for the record.