### PR TITLE
Always rebuild changelog doc via build-docs toxenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -259,6 +259,19 @@ commands =
   -git fetch --unshallow
   -git fetch --tags
 
+  # Rebuild the changelog html document specifically:
+  {envpython} -m sphinx \
+    -j auto \
+    -b html \
+    --color \
+    -E \
+    -n \
+    -W \
+    -d "{temp_dir}/.doctrees" \
+    . \
+    "{envdir}/docs_out" \
+    "{toxinidir}/docs/changelog.rst"
+
   # Build the html docs with Sphinx:
   {envpython} -m sphinx \
     -j auto \


### PR DESCRIPTION
This is a temporary workaround for
https://github.com/ansible/pylibssh/issues/120