### PR TITLE
📝 Use `dirhtml` builder on RTD

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ version: 2
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-  builder: html
+  builder: dirhtml
   configuration: docs/conf.py
   fail_on_warning: true
 

--- a/docs/changelog-fragments/127.misc.rst
+++ b/docs/changelog-fragments/127.misc.rst
@@ -1,0 +1,5 @@
+Switched the builder on `Read the Docs
+<https://readthedocs.org/>`__ to `dirhtml
+<https://www.sphinx-doc.org/en/master/usage/builders/index.html#sphinx.builders.dirhtml.DirectoryHTMLBuilder>`__
+so it now generates a dir-based URL layout for the website
+-- by :user:`webknjaz`


### PR DESCRIPTION
This builder creates a folder structure that allows serving docs
without the `filename.html` part by replacing it with
`filename/index.html` on disk so the URL would be in the form of
https://.../filename/ when served with a web-server as a static
website.

Ref: https://www.sphinx-doc.org/en/master/usage/builders/index.html#sphinx.builders.dirhtml.DirectoryHTMLBuilder