### PR TITLE
📝 Enable section ref targets autocreation

### DIFF
--- a/docs/changelog-fragments/128.misc.rst
+++ b/docs/changelog-fragments/128.misc.rst
@@ -1,0 +1,4 @@
+Enabled `sphinx.ext.autosectionlabel Sphinx extension
+<https://myst-parser.readthedocs.io/>`__ to automatically generate
+reference targets for document sections that can be linked
+against using ``:ref:`` -- by :user:`webknjaz`

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,3 @@
-.. _changelog:
-
 *********
 Changelog
 *********

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,6 +64,7 @@ nitpicky = True
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx.ext.autosectionlabel',  # autocreate section targets for refs
     'sphinx.ext.doctest',
     'sphinx.ext.extlinks',
     'sphinx.ext.intersphinx',


### PR DESCRIPTION
This change adds Sphinx's built-in `sphinx.ext.autosectionlabel`
extension that allows referencing sections by their titles via
the `:ref:` role.

Refs:
* https://www.sphinx-doc.org/en/master/usage/extensions/autosectionlabel.html
* https://myst-parser.readthedocs.io/en/latest/using/howto.html#automatically-create-targets-for-section-headers