### PR TITLE
Bump the minimum required tox to 3.19.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist = python
-minversion = 3.16.1
+minversion = 3.19.0
 requires =
     setuptools >= 40.9.0
     pip >= 19.0.3


### PR DESCRIPTION
This change makes sure that the in-tree PEP517 build backend of this
project is picked up and used by tox.

Fixes #72.

Refs:
* https://github.com/tox-dev/tox/issues/1575
* https://github.com/tox-dev/tox/pull/1614