### PR TITLE
👷 Prevent GHA workflows runs on branch creation

### DIFF
--- a/.github/workflows/build-test-n-publish.yml
+++ b/.github/workflows/build-test-n-publish.yml
@@ -24,6 +24,9 @@ on:
 jobs:
   pre-setup:
     name: Pre-set global build settings
+    if: >-  # https://twitter.com/webKnjaZ/status/1308803017001652225
+      github.event_name != 'create' ||
+      github.ref_type == 'tag'
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
This change prevents double and triple runs (create+push+pull_request), in particular those generated by dependabot.