### PR TITLE
Fix linking to libssh.so

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -100,5 +100,9 @@ pytest-parametrize-names-type = tuple
 pytest-parametrize-values-type = tuple
 pytest-parametrize-values-row-type = tuple
 
+# flake8-eradicate
+# E800:
+eradicate-whitelist-extend = distutils:\s+libraries\s+=\s+
+
 # wemake-python-styleguide
 show-source = true

--- a/.github/workflows/build-test-n-publish.yml
+++ b/.github/workflows/build-test-n-publish.yml
@@ -589,10 +589,6 @@ jobs:
         exclude:
         - dist-type: source
           runner-vm-os: ubuntu-16.04  # has too old libssh in the repos
-        - dist-type: source
-          runner-vm-os: ubuntu-18.04
-        - dist-type: source
-          runner-vm-os: ubuntu-20.04  # undefined symbol: ssh_disconnect
 
     env:
       ANSIBLE_PYLIBSSH_TRACING: >-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,6 +64,7 @@ repos:
     additional_dependencies:
     - flake8-2020>=1.6.0
     - flake8-docstrings
+    - flake8-eradicate>=1.0.0
     - flake8-pytest-style>=1.0.0
     - isort<5  # https://github.com/gforcada/flake8-isort/issues/88
     - wemake-python-styleguide

--- a/docs/changelog-fragments/158.bugfix.rst
+++ b/docs/changelog-fragments/158.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``undefined symbol: ssh_disconnect`` and related issues when building on certain distros -- by :user:`Qalthos`

--- a/src/pylibsshext/channel.pxd
+++ b/src/pylibsshext/channel.pxd
@@ -1,3 +1,4 @@
+# distutils: libraries = ssh
 #
 # This file is part of the pylibssh library
 #

--- a/src/pylibsshext/errors.pxd
+++ b/src/pylibsshext/errors.pxd
@@ -1,3 +1,4 @@
+# distutils: libraries = ssh
 #
 # This file is part of the pylibssh library
 #

--- a/src/pylibsshext/session.pxd
+++ b/src/pylibsshext/session.pxd
@@ -1,3 +1,4 @@
+# distutils: libraries = ssh
 #
 # This file is part of the pylibssh library
 #

--- a/src/pylibsshext/sftp.pxd
+++ b/src/pylibsshext/sftp.pxd
@@ -1,3 +1,4 @@
+# distutils: libraries = ssh
 #
 # This file is part of the pylibssh library
 #


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #103 and resolves #63.

The issue seems to be that the LDFLAGS env is not picked up or used
properly in some instances. Explicitly listing the link in the pxd files
causes the files to be built with `-lssh` properly.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request