### PR TITLE
Check for SSH_ERROR on channel_read_nonblocking

### DIFF
--- a/docs/changelog-fragments/168.bugfix.rst
+++ b/docs/changelog-fragments/168.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``"Negative size passed to PyBytes_FromStringAndSize"`` when ``ssh_channel_read_nonblocking`` fails -- by :user:`Qalthos`

--- a/src/pylibsshext/channel.pyx
+++ b/src/pylibsshext/channel.pyx
@@ -24,6 +24,7 @@ from cpython.mem cimport PyMem_Free, PyMem_Malloc, PyMem_Realloc
 from libc.string cimport memcpy, memset
 
 from pylibsshext.errors cimport LibsshChannelException
+from pylibsshext.errors import LibsshChannelReadFailure
 from pylibsshext.session cimport get_libssh_session
 
 from ._compat import CompletedProcess
@@ -105,7 +106,7 @@ cdef class Channel:
         if nbytes == libssh.SSH_ERROR:
             # This is what Session._get_session_error_str() does, but we don't have the Python object
             error = libssh.ssh_get_error(<void*>self._libssh_session).decode()
-            raise LibsshChannelException("Failed to read from channel: %s" % error)
+            raise LibsshChannelReadFailure(error)
         return <bytes>buffer[:nbytes]
 
     def recv(self, size=1024, stderr=0):

--- a/src/pylibsshext/channel.pyx
+++ b/src/pylibsshext/channel.pyx
@@ -102,6 +102,8 @@ cdef class Channel:
         if size_m > sizeof(buffer):
             size_m = sizeof(buffer)
         nbytes = libssh.ssh_channel_read_nonblocking(self._libssh_channel, buffer, size_m, stderr)
+        if nbytes == libssh.SSH_ERROR:
+            raise LibsshChannelException("Failed to read from channel")
         return <bytes>buffer[:nbytes]
 
     def recv(self, size=1024, stderr=0):

--- a/src/pylibsshext/channel.pyx
+++ b/src/pylibsshext/channel.pyx
@@ -103,7 +103,9 @@ cdef class Channel:
             size_m = sizeof(buffer)
         nbytes = libssh.ssh_channel_read_nonblocking(self._libssh_channel, buffer, size_m, stderr)
         if nbytes == libssh.SSH_ERROR:
-            raise LibsshChannelException("Failed to read from channel")
+            # This is what Session._get_session_error_str() does, but we don't have the Python object
+            error = libssh.ssh_get_error(<void*>self._libssh_session).decode()
+            raise LibsshChannelException("Failed to read from channel: %s" % error)
         return <bytes>buffer[:nbytes]
 
     def recv(self, size=1024, stderr=0):

--- a/src/pylibsshext/errors.pyx
+++ b/src/pylibsshext/errors.pyx
@@ -38,7 +38,13 @@ cdef class LibsshChannelException(LibsshException):
     pass
 
 
-class LibsshChannelReadFailure(LibsshChannelException, ConnectionError):
+try:  # py3
+    connection_error_exc = ConnectionError
+except NameError:  # py2
+    connection_error_exc = OSError
+
+
+class LibsshChannelReadFailure(LibsshChannelException, connection_error_exc):
     """Raised when there is a failure to read from a libssh channel."""
 
 

--- a/src/pylibsshext/errors.pyx
+++ b/src/pylibsshext/errors.pyx
@@ -33,11 +33,18 @@ cdef class LibsshException(Exception):
 cdef class LibsshSessionException(LibsshException):
     pass
 
+
 cdef class LibsshChannelException(LibsshException):
     pass
 
+
+class LibsshChannelReadFailure(LibsshChannelException, ConnectionError):
+    pass
+
+
 cdef class LibsshSCPException(LibsshException):
     pass
+
 
 cdef class LibsshSFTPException(LibsshException):
     pass

--- a/src/pylibsshext/errors.pyx
+++ b/src/pylibsshext/errors.pyx
@@ -39,7 +39,7 @@ cdef class LibsshChannelException(LibsshException):
 
 
 class LibsshChannelReadFailure(LibsshChannelException, ConnectionError):
-    pass
+    """Raised when there is a failure to read from a libssh channel."""
 
 
 cdef class LibsshSCPException(LibsshException):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
`libssh.ssh_channel_read_nonblocking()` can also return `SSH_ERROR`, which is helpfully defined as -1. This is not a valid buffer length.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
