### PR TITLE
Adjust the `get-pip.py` URL in CI for Python 3.5

### DIFF
--- a/.github/workflows/build-test-n-publish.yml
+++ b/.github/workflows/build-test-n-publish.yml
@@ -249,7 +249,7 @@ jobs:
         from python.org, if necessary, by installing certifi
       if: matrix.python-version == 3.5
       run: >-
-        curl https://bootstrap.pypa.io/get-pip.py
+        curl https://bootstrap.pypa.io/${{ matrix.python-version }}/get-pip.py
         |
         ${{ steps.install-python.outputs.binary }} - 'certifi'
     - name: Log official Python dist version from python.org


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This change updates the source for getting `get-pip.py` in GHA that we use to install `certify` under Python 3.5.

Fixes #169

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Since pip dropped support for Python 2.7 and 3.5, the `get-pip.py` script started using f-strings so we can't use it and should use a dedicated URL for Python 3.5.