### PR TITLE
Add manylinux_2_24 per PEP 600

### DIFF
--- a/.github/workflows/build-manylinux-container-images.yml
+++ b/.github/workflows/build-manylinux-container-images.yml
@@ -29,11 +29,16 @@ jobs:
           YEAR: 2010  # CentOS 6
         - ARCH: x86_64
           YEAR: 2014  # CentOS 7
+        - ARCH: x86_64
+          YEAR: _2_24  # CentOS 7, PEP 600
 
         # Build containers for aarch64 (ARM 64)
         - ARCH: aarch64
           QEMU_ARCH: arm64
           YEAR: 2014  # It's the first year aarch64 (ARM64) was included in PEP
+        - ARCH: aarch64
+          QEMU_ARCH: arm64
+          YEAR: _2_24  # PEP 600
 
         # # Build containers for armv7l (ARM v7)
         # - ARCH: armv7l
@@ -49,11 +54,17 @@ jobs:
         - ARCH: ppc64le
           QEMU_ARCH: ppc64le
           YEAR: 2014  # It's the first year ppc64le was included in PEP
+        - ARCH: ppc64le
+          QEMU_ARCH: ppc64le
+          YEAR: _2_24  # PEP 600
 
         # Build containers for s390x
         - ARCH: s390x
           QEMU_ARCH: s390x
           YEAR: 2014  # It's the first year s390x was included in PEP
+        - ARCH: s390x
+          QEMU_ARCH: s390x
+          YEAR: _2_24  # PEP 600
 
     env:
       PYPA_MANYLINUX_TAG: >-

--- a/build-scripts/manylinux-container-image/Dockerfile
+++ b/build-scripts/manylinux-container-image/Dockerfile
@@ -3,7 +3,21 @@ FROM quay.io/pypa/${RELEASE}
 ARG RELEASE
 MAINTAINER Python Cryptographic Authority
 WORKDIR /root
-RUN if [ $(uname -m) = "x86_64" ]; then yum -y install prelink && yum -y clean all; fi
+RUN \
+  if [ $(uname -m) = "x86_64" ]; \
+  then \
+    if stat /etc/redhat-release 1>&2 2>/dev/null; then \
+      yum -y install prelink && \
+      yum -y clean all && \
+      rm -rf /var/cache/yum; \
+    else \
+      export DEBIAN_FRONTEND=noninteractive && \
+      apt-get update -qq && \
+      apt-get install -qq -y --no-install-recommends prelink && \
+      apt-get clean -qq && \
+      rm -rf /var/lib/apt/lists/*; \
+    fi; \
+  fi
 ADD install_perl.sh /root/install_perl.sh
 RUN sh install_perl.sh
 ADD install_libffi.sh /root/install_libffi.sh

--- a/build-scripts/manylinux-container-image/Dockerfile
+++ b/build-scripts/manylinux-container-image/Dockerfile
@@ -19,15 +19,15 @@ RUN \
     fi; \
   fi
 ADD install_perl.sh /root/install_perl.sh
-RUN sh install_perl.sh
+RUN ./install_perl.sh
 ADD install_libffi.sh /root/install_libffi.sh
-RUN sh install_libffi.sh "${RELEASE}"
+RUN ./install_libffi.sh "${RELEASE}"
 ADD install_openssl.sh /root/install_openssl.sh
 ADD openssl-version.sh /root/openssl-version.sh
-RUN sh install_openssl.sh
+RUN ./install_openssl.sh
 
 ADD install_virtualenv.sh /root/install_virtualenv.sh
-RUN sh install_virtualenv.sh
+RUN ./install_virtualenv.sh
 
 # Install PyPy
 RUN if [ $(uname -m) = "x86_64" ]; then curl https://downloads.python.org/pypy/pypy3.6-v7.3.3-linux64.tar.bz2 | tar jxf - -C /opt/ && mv /opt/pypy3.6* /opt/pypy3.6; fi

--- a/build-scripts/manylinux-container-image/install_libffi.sh
+++ b/build-scripts/manylinux-container-image/install_libffi.sh
@@ -18,7 +18,7 @@ curl -#O "https://mirrors.ocf.berkeley.edu/debian/pool/main/libf/libffi/libffi_$
 check_sha256sum "libffi_${LIBFFI_VERSION}.orig.tar.gz" ${LIBFFI_SHA256}
 tar zxf libffi*.orig.tar.gz
 PATH=/opt/perl/bin:$PATH
-pushd libffi*
+pushd libffi*/
 if [[ "$1" =~ '^manylinux1_.*$' ]]; then
   STACK_PROTECTOR_FLAGS="-fstack-protector --param=ssp-buffer-size=4"
 else

--- a/build-scripts/manylinux-container-image/install_perl.sh
+++ b/build-scripts/manylinux-container-image/install_perl.sh
@@ -8,4 +8,4 @@ curl -O https://www.cpan.org/src/5.0/perl-5.24.1.tar.gz
 tar zxf perl-5.24.1.tar.gz && \
     cd perl-5.24.1 && \
     ./Configure -des -Dprefix=/opt/perl && \
-    make -j4 && make install
+    make -j && make install


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The latest manylinux-related scheme introduced the new universal tag scheme. This change enables GHA to build compatible base containerss.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Packaging Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Ref: https://www.python.org/dev/peps/pep-0600/