### PR TITLE
Move building static lib dependencies into the base manylinux image

### DIFF
--- a/.github/workflows/build-manylinux-container-images.yml
+++ b/.github/workflows/build-manylinux-container-images.yml
@@ -59,9 +59,9 @@ jobs:
           YEAR: _2_24  # PEP 600
 
         # Build containers for s390x
-        - ARCH: s390x
-          QEMU_ARCH: s390x
-          YEAR: 2014  # It's the first year s390x was included in PEP
+        # - ARCH: s390x
+        #   QEMU_ARCH: s390x
+        #   YEAR: 2014  # It's the first year s390x was included in PEP
         - ARCH: s390x
           QEMU_ARCH: s390x
           YEAR: _2_24  # PEP 600

--- a/.github/workflows/build-manylinux-container-images.yml
+++ b/.github/workflows/build-manylinux-container-images.yml
@@ -67,6 +67,7 @@ jobs:
           YEAR: _2_24  # PEP 600
 
     env:
+      LIBSSH_VERSION: 0.9.4
       PYPA_MANYLINUX_TAG: >-
         manylinux${{ matrix.IMAGE.YEAR }}_${{ matrix.IMAGE.ARCH }}
       FULL_IMAGE_NAME: >-
@@ -98,11 +99,17 @@ jobs:
       with:
         archs: linux/${{ env.QEMU_ARCH }}
         image: ${{ env.FULL_IMAGE_NAME }}
-        tags: latest
+        tags: >-
+          latest
+          libssh-v${{ env.LIBSSH_VERSION }}_gh-${{ github.sha }}
+          libssh-v${{ env.LIBSSH_VERSION }}
+          ${{ github.sha }}
         dockerfiles: build-scripts/manylinux-container-image/Dockerfile
         context: build-scripts/manylinux-container-image/
         oci: true  # Should be alright because we don't publish to Docker Hub
-        build-args: RELEASE=${{ env.PYPA_MANYLINUX_TAG }}
+        build-args: |
+          LIBSSH_VERSION=${{ env.LIBSSH_VERSION }}
+          RELEASE=${{ env.PYPA_MANYLINUX_TAG }}
     - name: Push to GitHub Container Registry
       if: >-
         (github.event_name == 'push' || github.event_name == 'schedule')

--- a/build-scripts/build-all-manylinux-wheels.sh
+++ b/build-scripts/build-all-manylinux-wheels.sh
@@ -4,15 +4,7 @@ then
     set -x
 fi
 
-LIBSSH_VERSION="$1"
-
 set -Eeuo pipefail
-
-if [ -z "$LIBSSH_VERSION" ]
-then
-    >&2 echo "Please pass libssh version as a first argument of this script ($0)"
-    exit 1
-fi
 
 manylinux1_image_prefix="quay.io/pypa/manylinux1_"
 manylinux1_image_prefix="pyca/cryptography-manylinux1:"
@@ -40,7 +32,7 @@ do
 
     echo Building wheel for $arch arch
     #docker run --rm -v `pwd`:/io "${manylinux1_image_prefix}${arch}" $dock_ext_args /io/build-scripts/build-manylinux-wheels.sh "$LIBSSH_VERSION" &
-    podman run --rm -v `pwd`:/io "${manylinux1_image_prefix}${arch}" $dock_ext_args /io/build-scripts/build-manylinux-wheels.sh "$LIBSSH_VERSION" &
+    podman run --rm -v `pwd`:/io "${manylinux1_image_prefix}${arch}" $dock_ext_args /io/build-scripts/build-manylinux-wheels.sh &
 
     dock_ext_args=""  # Reset docker args, just in case
 done

--- a/build-scripts/build-manylinux-wheels.sh
+++ b/build-scripts/build-manylinux-wheels.sh
@@ -7,8 +7,7 @@ then
     set -x
 fi
 
-LIBSSH_VERSION="$1"
-PYTHON_TARGET="$2"
+PYTHON_TARGET="${1}"
 
 set -Eeuo pipefail
 
@@ -23,12 +22,6 @@ IMPORTABLE_PKG="$(ls "${SRC_DIR}/src/")"  # must contain only one dir
 
 >&2 echo Verifying that $IMPORTABLE_PKG can be the target package...
 >/dev/null stat ${SRC_DIR}/src/${IMPORTABLE_PKG}/*.p{y,yx,xd}
-
-if [ -z "$LIBSSH_VERSION" ]
-then
-    >&2 echo "Please pass libssh version as a first argument of this script ($0)"
-    exit 1
-fi
 
 PYTHONS="$(ls -1 --ignore=cp34-cp34m /opt/python/ | sort -r)"
 if [ -n "${PYTHON_TARGET}" ]
@@ -67,9 +60,6 @@ BUILD_DIR=`mktemp -d "/tmp/${DIST_NAME}-manylinux1-build.XXXXXXXXXX"`
 TESTS_DIR="${BUILD_DIR}/tests"
 STATIC_DEPS_PREFIX="$(get_static_deps_dir)"
 
-LIBSSH_CLONE_DIR="${BUILD_DIR}/libssh"
-LIBSSH_BUILD_DIR="${LIBSSH_CLONE_DIR}/build"
-
 ORIG_WHEEL_DIR="${BUILD_DIR}/original-wheelhouse"
 WHEEL_DEP_DIR="${BUILD_DIR}/deps-wheelhouse"
 MANYLINUX_DIR="${BUILD_DIR}/manylinux-wheelhouse"
@@ -78,54 +68,25 @@ UNPACKED_WHEELS_DIR="${BUILD_DIR}/unpacked-wheels"
 VENVS_DIR="${BUILD_DIR}/venvs"
 ISOLATED_SRC_DIRS="${BUILD_DIR}/src"
 
-export PYCA_OPENSSL_PATH=/opt/pyca/cryptography/openssl
-export OPENSSL_PATH=/opt/openssl
+# NOTE: `LDFLAGS` is necessary for the C-extension build's linker to
+# NOTE: locate the symbols in the libssh shared object files.
+# NOTE: Otherwise, the error is:
+#
+#   gcc -pthread -shared -lssh -I/opt/manylinux-static-deps.PPkLKziXI7/include -DCYTHON_TRACE=1 -DCYTHON_TRACE_NOGIL=1 /tmp/pip-req-build-4h841og7/src/tmpy3l03tmj/tmp/pip-req-build-4h841og7/src/pylibsshext/session.o -lssh -o build/lib.linux-x86_64-3.9/pylibsshext/session.cpython-39-x86_64-linux-gnu.so
+#   /opt/rh/devtoolset-2/root/usr/libexec/gcc/x86_64-CentOS-linux/4.8.2/ld: cannot find -lssh
+#   /opt/rh/devtoolset-2/root/usr/libexec/gcc/x86_64-CentOS-linux/4.8.2/ld: cannot find -lssh
+#   collect2: error: ld returned 1 exit status
+#   error: command '/opt/rh/devtoolset-2/root/usr/bin/gcc' failed with exit code 1
+#   ----------------------------------------
+#   ERROR: Failed building wheel for ansible-pylibssh
+# Failed to build ansible-pylibssh
+# ERROR: Failed to build one or more wheels
+export LDFLAGS="'-L${STATIC_DEPS_PREFIX}/lib64' '-L${STATIC_DEPS_PREFIX}/lib'"
 
-export LDFLAGS="-pthread -ldl '-L${STATIC_DEPS_PREFIX}/lib64' '-L${STATIC_DEPS_PREFIX}/lib'"
-#export CPPFLAGS="-lpthread"
+# NOTE: `LD_LIBRARY_PATH` is necessary so that `auditwheel repair` could locate `libssh.so.4`
 export LD_LIBRARY_PATH="${STATIC_DEPS_PREFIX}/lib64:${STATIC_DEPS_PREFIX}/lib:$LD_LIBRARY_PATH"
-export PKG_CONFIG_PATH="${STATIC_DEPS_PREFIX}/lib64/pkgconfig:${STATIC_DEPS_PREFIX}/lib/pkgconfig:${OPENSSL_PATH}/lib/pkgconfig:${PYCA_OPENSSL_PATH}/lib/pkgconfig"
 
 ARCH=`uname -m`
-
-
->&2 echo
->&2 echo
->&2 echo ================================================
->&2 echo downloading source of libssh v${LIBSSH_VERSION}:
->&2 echo ================================================
->&2 echo
-git clone \
-    --depth=1 \
-    -b "libssh-${LIBSSH_VERSION}" \
-    https://git.libssh.org/projects/libssh.git \
-    "${LIBSSH_CLONE_DIR}"
-
-mkdir -p "${LIBSSH_BUILD_DIR}"
-pushd "${LIBSSH_BUILD_DIR}"
-# For some reason, libssh has to be compiled as a shared object.
-# If not, imports fail at runtime, with undefined symbols:
-# ```python-traceback
-# test/units/test_sftp.py:7: in <module>
-#     from pylibsshext.sftp import SFTP
-# E   ImportError: /opt/python/cp27-cp27m/lib/python2.7/site-packages/pylibsshext/sftp.so: undefined symbol: sftp_get_error
-# ```
-# Also, when compiled statically, manylinux2010 container turns dist
-# into manylinux1 but because of the reason above, it doesn't make sense.
-cmake "${LIBSSH_CLONE_DIR}" \
-    -DCMAKE_INSTALL_PREFIX="${STATIC_DEPS_PREFIX}" \
-    -DCMAKE_BUILD_TYPE=MinSizeRel \
-    -DBUILD_SHARED_LIBS=ON \
-    -DCLIENT_TESTING=OFF \
-    -DSERVER_TESTING=OFF \
-    -DUNIT_TESTING=OFF \
-    -DWITH_GSSAPI=OFF \
-    -DWITH_SERVER=OFF \
-    -DWITH_PCAP=OFF \
-    -DWITH_ZLIB=ON
-make
-make install/strip
-popd
 
 >&2 echo
 >&2 echo
@@ -146,7 +107,7 @@ done
 >&2 echo Building wheels:
 >&2 echo ================
 >&2 echo
-export CFLAGS="'-I${LIBSSH_CLONE_DIR}/include' '-I${STATIC_DEPS_PREFIX}/include' '-I${BUILD_DIR}/libssh/include'"
+export CFLAGS="'-I${STATIC_DEPS_PREFIX}/include'"
 for PY in $PYTHONS; do
     PIP_BIN="/opt/python/${PY}/bin/pip"
     >&2 echo Using "${PIP_BIN}"...

--- a/build-scripts/build-manylinux-wheels.sh
+++ b/build-scripts/build-manylinux-wheels.sh
@@ -13,6 +13,7 @@ PYTHON_TARGET="$2"
 set -Eeuo pipefail
 
 source get-static-deps-dir.sh
+source activate-userspace-tools.sh
 
 SRC_DIR=/io
 PERM_REF_HOST_FILE="${SRC_DIR}/setup.cfg"
@@ -53,7 +54,7 @@ echo "${PYTHONS}" | >&2 tr ' ' '\n'
 # Avoid creation of __pycache__/*.py[c|o]
 export PYTHONDONTWRITEBYTECODE=1
 
-export PATH="${HOME}/.tools-venv/bin:${HOME}/.local/bin/:$PATH"
+import_userspace_tools
 
 PIP_GLOBAL_ARGS=
 if [ -n "$DEBUG" ]
@@ -87,16 +88,6 @@ export PKG_CONFIG_PATH="${STATIC_DEPS_PREFIX}/lib64/pkgconfig:${STATIC_DEPS_PREF
 
 ARCH=`uname -m`
 
-
->&2 echo
->&2 echo
->&2 echo ==============================================
->&2 echo Installing build deps into a dedicated venv...
->&2 echo ==============================================
->&2 echo
-/opt/python/cp38-cp38/bin/python -m venv ~/.tools-venv
-~/.tools-venv/bin/pip install -U pip setuptools
-~/.tools-venv/bin/pip install --use-feature=2020-resolver auditwheel cmake
 
 >&2 echo
 >&2 echo

--- a/build-scripts/build-manylinux-wheels.sh
+++ b/build-scripts/build-manylinux-wheels.sh
@@ -12,6 +12,8 @@ PYTHON_TARGET="$2"
 
 set -Eeuo pipefail
 
+source get-static-deps-dir.sh
+
 SRC_DIR=/io
 PERM_REF_HOST_FILE="${SRC_DIR}/setup.cfg"
 PEP517_CONFIG_FILE="${SRC_DIR}/pyproject.toml"
@@ -62,10 +64,7 @@ GIT_GLOBAL_ARGS="--git-dir=${SRC_DIR}/.git --work-tree=${SRC_DIR}"
 TESTS_SRC_DIR="${SRC_DIR}/tests"
 BUILD_DIR=`mktemp -d "/tmp/${DIST_NAME}-manylinux1-build.XXXXXXXXXX"`
 TESTS_DIR="${BUILD_DIR}/tests"
-STATIC_DEPS_PREFIX="${BUILD_DIR}/static-deps"
-
-ZLIB_VERSION=1.2.11
-ZLIB_DOWNLOAD_DIR="${BUILD_DIR}/zlib-${ZLIB_VERSION}"
+STATIC_DEPS_PREFIX="$(get_static_deps_dir)"
 
 LIBSSH_CLONE_DIR="${BUILD_DIR}/libssh"
 LIBSSH_BUILD_DIR="${LIBSSH_CLONE_DIR}/build"
@@ -82,7 +81,6 @@ export PYCA_OPENSSL_PATH=/opt/pyca/cryptography/openssl
 export OPENSSL_PATH=/opt/openssl
 
 export LDFLAGS="-pthread -ldl '-L${STATIC_DEPS_PREFIX}/lib64' '-L${STATIC_DEPS_PREFIX}/lib'"
-export CFLAGS="-fPIC"
 #export CPPFLAGS="-lpthread"
 export LD_LIBRARY_PATH="${STATIC_DEPS_PREFIX}/lib64:${STATIC_DEPS_PREFIX}/lib:$LD_LIBRARY_PATH"
 export PKG_CONFIG_PATH="${STATIC_DEPS_PREFIX}/lib64/pkgconfig:${STATIC_DEPS_PREFIX}/lib/pkgconfig:${OPENSSL_PATH}/lib/pkgconfig:${PYCA_OPENSSL_PATH}/lib/pkgconfig"
@@ -99,23 +97,6 @@ ARCH=`uname -m`
 /opt/python/cp38-cp38/bin/python -m venv ~/.tools-venv
 ~/.tools-venv/bin/pip install -U pip setuptools
 ~/.tools-venv/bin/pip install --use-feature=2020-resolver auditwheel cmake
-
->&2 echo
->&2 echo
->&2 echo ============================================
->&2 echo downloading source of zlib v${ZLIB_VERSION}:
->&2 echo ============================================
->&2 echo
-curl https://www.zlib.net/zlib-${ZLIB_VERSION}.tar.gz | \
-    tar xzvC "${BUILD_DIR}" -f -
-
-pushd "${ZLIB_DOWNLOAD_DIR}"
-./configure \
-    --static \
-    --prefix="${STATIC_DEPS_PREFIX}" && \
-    make -j9 libz.a && \
-    make install
-popd
 
 >&2 echo
 >&2 echo
@@ -174,7 +155,7 @@ done
 >&2 echo Building wheels:
 >&2 echo ================
 >&2 echo
-export CFLAGS="'-I${LIBSSH_CLONE_DIR}/include' '-I${STATIC_DEPS_PREFIX}/include' '-I${BUILD_DIR}/libssh/include' ${CFLAGS}"
+export CFLAGS="'-I${LIBSSH_CLONE_DIR}/include' '-I${STATIC_DEPS_PREFIX}/include' '-I${BUILD_DIR}/libssh/include'"
 for PY in $PYTHONS; do
     PIP_BIN="/opt/python/${PY}/bin/pip"
     >&2 echo Using "${PIP_BIN}"...

--- a/build-scripts/manylinux-container-image/Dockerfile
+++ b/build-scripts/manylinux-container-image/Dockerfile
@@ -35,3 +35,11 @@ RUN if [ $(uname -m) = "x86_64" ]; then curl https://downloads.python.org/pypy/p
 
 RUN if ! [[ ${RELEASE} =~ '^manylinux1_.*$' ]]; then curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable --profile minimal; fi
 ENV PATH="/root/.cargo/bin:$PATH"
+
+# \pylibssh
+ADD make-static-deps-dir.sh /root/make-static-deps-dir.sh
+ADD get-static-deps-dir.sh /root/get-static-deps-dir.sh
+RUN ./make-static-deps-dir.sh
+ADD install_zlib.sh /root/install_zlib.sh
+RUN ./install_zlib.sh
+# /pylibssh

--- a/build-scripts/manylinux-container-image/Dockerfile
+++ b/build-scripts/manylinux-container-image/Dockerfile
@@ -1,6 +1,7 @@
 ARG RELEASE
 FROM quay.io/pypa/${RELEASE}
 ARG RELEASE
+ARG LIBSSH_VERSION=0.9.4
 MAINTAINER Python Cryptographic Authority
 WORKDIR /root
 RUN \
@@ -45,4 +46,6 @@ ADD get-static-deps-dir.sh /root/get-static-deps-dir.sh
 RUN ./make-static-deps-dir.sh
 ADD install_zlib.sh /root/install_zlib.sh
 RUN ./install_zlib.sh
+ADD install_libssh.sh /root/install_libssh.sh
+RUN ./install_libssh.sh "${LIBSSH_VERSION}"
 # /pylibssh

--- a/build-scripts/manylinux-container-image/Dockerfile
+++ b/build-scripts/manylinux-container-image/Dockerfile
@@ -37,6 +37,9 @@ RUN if ! [[ ${RELEASE} =~ '^manylinux1_.*$' ]]; then curl https://sh.rustup.rs -
 ENV PATH="/root/.cargo/bin:$PATH"
 
 # \pylibssh
+ADD install-userspace-tools.sh /root/install-userspace-tools.sh
+ADD activate-userspace-tools.sh /root/activate-userspace-tools.sh
+RUN ./install-userspace-tools.sh
 ADD make-static-deps-dir.sh /root/make-static-deps-dir.sh
 ADD get-static-deps-dir.sh /root/get-static-deps-dir.sh
 RUN ./make-static-deps-dir.sh

--- a/build-scripts/manylinux-container-image/activate-userspace-tools.sh
+++ b/build-scripts/manylinux-container-image/activate-userspace-tools.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -xe
+
+USERSPACE_LOCAL_BIN_PATH="${HOME}/.local/bin"
+USERSPACE_VENV_PATH="${HOME}/.tools-venv"
+USERSPACE_VENV_BIN_PATH="${USERSPACE_VENV_PATH}/bin"
+
+PATH="${USERSPACE_VENV_BIN_PATH}:${USERSPACE_LOCAL_BIN_PATH}:${PATH}"
+
+function import_userspace_tools {
+    export USERSPACE_VENV_PATH
+    export USERSPACE_VENV_BIN_PATH
+    export PATH
+}
+
+export import_userspace_tools

--- a/build-scripts/manylinux-container-image/get-static-deps-dir.sh
+++ b/build-scripts/manylinux-container-image/get-static-deps-dir.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -xe
+
+STATIC_DEPS_DIR_STORAGE=.static-deps-path
+STATIC_DEPS_DIR=$(cat "${STATIC_DEPS_DIR_STORAGE}")
+
+function get_static_deps_dir {
+    echo "${STATIC_DEPS_DIR}"
+}
+
+export get_static_deps_dir

--- a/build-scripts/manylinux-container-image/install-userspace-tools.sh
+++ b/build-scripts/manylinux-container-image/install-userspace-tools.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -x
+
+set -Eeuo pipefail
+
+source activate-userspace-tools.sh
+import_userspace_tools
+
+ARCH=$(uname -m)
+PYTHON_INTERPRETER=/opt/python/cp39-cp39/bin/python
+VIRTUALENV_PYTHON_BIN="${USERSPACE_VENV_BIN_PATH}/python"
+VIRTUALENV_PIP_BIN="${VIRTUALENV_PYTHON_BIN} -m pip"
+
+TOOLS_PKGS=auditwheel
+if [ "${ARCH}" == "x86_64" ]
+then
+    TOOLS_PKGS="${TOOLS_PKGS} cmake"
+fi
+
+# Avoid creation of __pycache__/*.py[c|o]
+export PYTHONDONTWRITEBYTECODE=1
+
+>&2 echo
+>&2 echo
+>&2 echo ============================================================================
+>&2 echo Installing build deps into a dedicated venv at "'${USERSPACE_VENV_PATH}'"...
+>&2 echo ============================================================================
+>&2 echo
+"${PYTHON_INTERPRETER}" -m venv "${USERSPACE_VENV_PATH}"
+${VIRTUALENV_PIP_BIN} install -U pip-with-requires-python
+${VIRTUALENV_PIP_BIN} install -U setuptools wheel
+${VIRTUALENV_PIP_BIN} install ${TOOLS_PKGS}

--- a/build-scripts/manylinux-container-image/install_libssh.sh
+++ b/build-scripts/manylinux-container-image/install_libssh.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+set -x
+
+LIB_VERSION="$1"
+
+set -Eeuo pipefail
+
+unset RELEASE
+
+source get-static-deps-dir.sh
+
+LIB_NAME=libssh
+BUILD_DIR=$(mktemp -d "/tmp/${LIB_NAME}-${LIB_VERSION}-manylinux-build.XXXXXXXXXX")
+
+LIB_CLONE_DIR="${BUILD_DIR}/${LIB_NAME}-${LIB_VERSION}"
+LIB_BUILD_DIR="${LIB_CLONE_DIR}/build"
+
+STATIC_DEPS_PREFIX="$(get_static_deps_dir)"
+
+if [ -z "${LIB_VERSION}" ]
+then
+    >&2 echo "Please pass libssh version as a first argument of this script (${0})"
+    exit 1
+fi
+
+# NOTE: `LDFLAGS` is necessary for the linker to locate the symbols for
+# NOTE: things like `dlopen', `dlclose', `pthread_atfork', `dlerror',
+# NOTE: `dlsym', `dladdr' etc.
+# NOTE: Otherwise, the build failure looks as follows:
+#
+# [ 66%] Linking C executable libssh_scp
+# ../lib/libssh.so.4.8.5: undefined reference to `dlopen'
+# ../lib/libssh.so.4.8.5: undefined reference to `dlclose'
+# ../lib/libssh.so.4.8.5: undefined reference to `pthread_atfork'
+# ../lib/libssh.so.4.8.5: undefined reference to `dlerror'
+# ../lib/libssh.so.4.8.5: undefined reference to `dlsym'
+# ../lib/libssh.so.4.8.5: undefined reference to `dladdr'
+# collect2: error: ld returned 1 exit status
+# make[2]: *** [examples/libssh_scp] Error 1
+# make[1]: *** [examples/CMakeFiles/libssh_scp.dir/all] Error 2
+# make: *** [all] Error 2
+export LDFLAGS="-pthread -ldl"
+
+# NOTE: `PKG_CONFIG_PATH` is necessary for `cmake` to be able to locate
+# NOTE: C-headers files `*.h`. Otherwise, the error is:
+#
+# -- Found ZLIB: /opt/manylinux-static-deps.PPkLKziXI7/lib/libz.a (found version "1.2.11") 
+# -- Could NOT find OpenSSL, try to set the path to OpenSSL root folder in the system variable OPENSSL_ROOT_DIR (missing: OPENSSL_CRYPTO_LIBRARY OPENSSL_INCLUDE_DIR) 
+# -- Could NOT find GCrypt, try to set the path to GCrypt root folder in the system variable GCRYPT_ROOT_DIR (missing: GCRYPT_INCLUDE_DIR GCRYPT_LIBRARIES) 
+# CMake Warning (dev) at /root/.tools-venv/lib/python3.9/site-packages/cmake/data/share/cmake-3.18/Modules/FindPackageHandleStandardArgs.cmake:273 (message):
+#   The package name passed to `find_package_handle_standard_args` (MBedTLS)
+#   does not match the name of the calling package (MbedTLS).  This can lead to
+#   problems in calling code that expects `find_package` result variables
+#   (e.g., `_FOUND`) to follow a certain pattern.
+# Call Stack (most recent call first):
+#   cmake/Modules/FindMbedTLS.cmake:96 (find_package_handle_standard_args)
+#   CMakeLists.txt:65 (find_package)
+# This warning is for project developers.  Use -Wno-dev to suppress it.
+#
+# -- Could NOT find mbedTLS, try to set the path to mbedLS root folder in
+#         the system variable MBEDTLS_ROOT_DIR (missing: MBEDTLS_INCLUDE_DIR MBEDTLS_LIBRARIES) 
+# CMake Error at CMakeLists.txt:67 (message):
+#   Could not find OpenSSL, GCrypt or mbedTLS
+#
+#
+# -- Configuring incomplete, errors occurred!
+# See also "/tmp/libssh-0.9.4-manylinux-build.FJUercWAg9/libssh-0.9.4/build/CMakeFiles/CMakeOutput.log".
+# See also "/tmp/libssh-0.9.4-manylinux-build.FJUercWAg9/libssh-0.9.4/build/CMakeFiles/CMakeError.log".
+export PYCA_OPENSSL_PATH=/opt/pyca/cryptography/openssl
+export PKG_CONFIG_PATH="${STATIC_DEPS_PREFIX}/lib64/pkgconfig:${STATIC_DEPS_PREFIX}/lib/pkgconfig:${PYCA_OPENSSL_PATH}/lib/pkgconfig"
+
+>&2 echo
+>&2 echo
+>&2 echo ==================================================
+>&2 echo downloading source of ${LIB_NAME} v${LIB_VERSION}:
+>&2 echo ==================================================
+>&2 echo
+git clone \
+    --depth=1 \
+    -b "${LIB_NAME}-${LIB_VERSION}" \
+    https://git.libssh.org/projects/${LIB_NAME}.git \
+    "${LIB_CLONE_DIR}"
+
+source activate-userspace-tools.sh
+import_userspace_tools
+
+mkdir -pv "${LIB_BUILD_DIR}"
+pushd "${LIB_BUILD_DIR}"
+# For some reason, libssh has to be compiled as a shared object.
+# If not, imports fail at runtime, with undefined symbols:
+# ```python-traceback
+# test/units/test_sftp.py:7: in <module>
+#     from pylibsshext.sftp import SFTP
+# E   ImportError: /opt/python/cp27-cp27m/lib/python2.7/site-packages/pylibsshext/sftp.so: undefined symbol: sftp_get_error
+# ```
+# Also, when compiled statically, manylinux2010 container turns dist
+# into manylinux1 but because of the reason above, it doesn't make sense.
+cmake "${LIB_CLONE_DIR}" \
+    -DCMAKE_INSTALL_PREFIX="${STATIC_DEPS_PREFIX}" \
+    -DCMAKE_BUILD_TYPE=MinSizeRel \
+    -DBUILD_SHARED_LIBS=ON \
+    -DCLIENT_TESTING=OFF \
+    -DSERVER_TESTING=OFF \
+    -DUNIT_TESTING=OFF \
+    -DWITH_GSSAPI=OFF \
+    -DWITH_SERVER=OFF \
+    -DWITH_PCAP=OFF \
+    -DWITH_ZLIB=ON
+make
+make install/strip
+popd
+
+rm -rf "${BUILD_DIR}"

--- a/build-scripts/manylinux-container-image/install_zlib.sh
+++ b/build-scripts/manylinux-container-image/install_zlib.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -xe
+
+unset RELEASE
+
+source get-static-deps-dir.sh
+
+LIB_NAME=zlib
+BUILD_DIR=$(mktemp -d "/tmp/${LIB_NAME}-manylinux-build.XXXXXXXXXX")
+
+LIB_VERSION=1.2.11
+LIB_DOWNLOAD_DIR="${BUILD_DIR}/${LIB_NAME}-${LIB_VERSION}"
+
+STATIC_DEPS_PREFIX="$(get_static_deps_dir)"
+
+export CFLAGS="-fPIC"
+
+>&2 echo
+>&2 echo
+>&2 echo ============================================
+>&2 echo downloading source of ${LIB_NAME} v${LIB_VERSION}:
+>&2 echo ============================================
+>&2 echo
+curl https://www.zlib.net/${LIB_NAME}-${LIB_VERSION}.tar.gz | \
+    tar xzvC "${BUILD_DIR}" -f -
+
+pushd "${LIB_DOWNLOAD_DIR}"
+./configure \
+    --static \
+    --prefix="${STATIC_DEPS_PREFIX}" && \
+    make -j libz.a && \
+    make install
+popd
+
+rm -rf "${BUILD_DIR}"

--- a/build-scripts/manylinux-container-image/make-static-deps-dir.sh
+++ b/build-scripts/manylinux-container-image/make-static-deps-dir.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -xe
+
+STATIC_DEPS_DIR_STORAGE=.static-deps-path
+STATIC_DEPS_DIR="$(mktemp -d '/opt/manylinux-static-deps.XXXXXXXXXX')"
+
+mkdir -pv "${STATIC_DEPS_DIR}"
+echo "${STATIC_DEPS_DIR}" > "${STATIC_DEPS_DIR_STORAGE}"
+
+>&2 echo
+>&2 echo
+>&2 echo ==================================================================================================
+>&2 echo Created static deps path "'${STATIC_DEPS_DIR}'" and stored it to "'${STATIC_DEPS_DIR_STORAGE}'"...
+>&2 echo ==================================================================================================
+>&2 echo


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
$sbj. This should help us speed-up the manylinux wheel builds because the deps and the build system prerequisites would already be pre-baked in the container image.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Packaging Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
N/A