### PR TITLE
Switch from `pep517` lib to `build` CLI

### DIFF
--- a/.github/workflows/build-test-n-publish.yml
+++ b/.github/workflows/build-test-n-publish.yml
@@ -172,7 +172,7 @@ jobs:
     env:
       ANSIBLE_PYLIBSSH_TRACING: >-
         ${{ fromJSON(needs.pre-setup.outputs.profiling_enabled) && 1 || 0 }}
-      PEP517_ARGS: --binary
+      PEP517_BUILD_ARGS: --wheel
       PY_COLORS: 1
       TOXENV: build-wheels-pip,delocate-macos-wheels,metadata-validation
       TOX_PARALLEL_NO_SPINNER: 1
@@ -580,7 +580,7 @@ jobs:
     env:
       ANSIBLE_PYLIBSSH_TRACING: >-
         ${{ fromJSON(needs.pre-setup.outputs.profiling_enabled) && 1 || 0 }}
-      PEP517_ARGS: --source
+      PEP517_BUILD_ARGS: --sdist
       PY_COLORS: 1
       TOXENV: build-dists,metadata-validation
       TOX_PARALLEL_NO_SPINNER: 1

--- a/docs/changelog-fragments/199.misc.rst
+++ b/docs/changelog-fragments/199.misc.rst
@@ -1,0 +1,2 @@
+Switched using `pep517 <https://pep517.rtfd.io>`__ lib to
+`build <https://pypa-build.rtfd.io>`__ CLI -- :user:`webknjaz`

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist = python
-minversion = 3.19.0
+minversion = 3.21.0
 requires =
     setuptools >= 40.9.0
     pip >= 19.0.3
@@ -91,7 +91,7 @@ setenv =
 [dists]
 setenv =
     {[testenv]setenv}
-    PEP517_OUT_DIR = {env:PEP517_OUT_DIR:{toxinidir}/dist}
+    PEP517_OUT_DIR = {env:PEP517_OUT_DIR:{toxinidir}{/}dist}
 
 
 [testenv:cleanup-dists]
@@ -118,18 +118,16 @@ isolated_build = true
 usedevelop = false
 skip_install = true
 deps =
-    # NOTE: v0.7.0 added support for backend-path in pyproject.toml but
-    # NOTE: why not use something newer if we can?
-    pep517 >= 0.8.2
+    build >= 0.3.1, < 0.4.0
 passenv =
-    PEP517_ARGS
+    PEP517_BUILD_ARGS
 setenv =
     {[dists]setenv}
 commands =
-    {envpython} -m pep517.build \
-      {env:PEP517_ARGS:--source --binary} \
-      --out-dir {env:PEP517_OUT_DIR} \
-      {toxinidir}
+    {envpython} -m build \
+      --outdir '{env:PEP517_OUT_DIR}{/}' \
+      {posargs:{env:PEP517_BUILD_ARGS:--sdist --wheel}} \
+      '{toxinidir}'
 
 
 [testenv:build-wheels-pip]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This is necessary because `pep517` is going to drop its experimental
CLIs eventually and the PyPA recomments using a new tool called
`build` instead. `pypa/build` is a CLI built around the APIs provided
by the `pep517` library.

Refs:
* https://github.com/pypa/pep517/pull/83
* https://github.com/pypa/pep517/issues/91

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Packaging Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
N/A