### PR TITLE
Implement a cross-platform RPM spec

### DIFF
--- a/.github/workflows/build-test-n-publish.yml
+++ b/.github/workflows/build-test-n-publish.yml
@@ -676,6 +676,176 @@ jobs:
         path: dist
         retention-days: 4
 
+  build-rpms:
+    name: ${{ matrix.target-container.tag }}
+    needs:
+    - build-src
+    - pre-setup  # transitive, for accessing settings
+    strategy:
+      matrix:
+        target-container:
+        - tag: fedora:34
+        - tag: centos:8
+        - tag: centos/centos:stream8
+          registry: quay.io
+        - tag: ubi8/ubi
+          registry: registry.access.redhat.com
+    runs-on: ubuntu-latest
+    container:
+      # NOTE: GHA has poor support for concat which is why I resorted to
+      # NOTE: using this ugly ternary syntax
+      image: >-
+        ${{
+          matrix.target-container.registry
+          && matrix.target-container.registry
+          || ''
+        }}${{
+          matrix.target-container.registry
+          && '/'
+          || ''
+        }}${{
+          matrix.target-container.tag
+        }}
+
+    steps:
+    - name: Enable EPEL repository
+      if: contains(matrix.target-container.tag, 'centos')
+      run: dnf install --assumeyes epel-release
+
+    - name: Install build tooling
+      run: >-
+        dnf install
+        --assumeyes
+        dnf-plugins-core
+        rpm-build
+        ${{
+            !contains(matrix.target-container.tag, 'ubi')
+            && 'rpmdevtools rpmlint'
+            || ''
+        }}
+
+    - name: Create rpmbuild directory structure on a community distro
+      if: >-
+        !contains(matrix.target-container.tag, 'ubi')
+      run: rpmdev-setuptree
+    - name: Create rpmbuild directory structure on RHEL
+      if: contains(matrix.target-container.tag, 'ubi')
+      run: mkdir -pv ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+
+    - name: Grab the source from Git
+      uses: actions/checkout@v2
+
+    - name: Set an SCM version in the spec
+      run: >-
+        sed -i
+        "s#^\(Version:\s\+\).*#\1${{ needs.pre-setup.outputs.dist_version }}#"
+        packaging/rpm/ansible-pylibssh.spec
+
+    - name: Lint the RPM spec file
+      if: >-
+        !contains(matrix.target-container.tag, 'ubi')
+      run: rpmlint packaging/rpm/ansible-pylibssh.spec
+
+    - name: Download all the dists
+      uses: actions/download-artifact@v2
+      with:
+        name: python-package-distributions
+        path: dist/
+
+    - name: Copy sdist to the sources dir
+      run: >-
+        cp -v
+        dist/ansible-pylibssh-${{ needs.pre-setup.outputs.dist_version }}.tar.gz
+        ~/rpmbuild/SOURCES/
+
+    - name: Install static build dependencies missing from UBI
+      if: contains(matrix.target-container.tag, 'ubi')
+      run: >-
+        dnf install
+        --assumeyes
+        https://rpmfind.net/linux/centos/8-stream/AppStream/x86_64/os/Packages/cmake-filesystem-3.18.2-9.el8.x86_64.rpm
+        https://rpmfind.net/linux/centos/8-stream/AppStream/x86_64/os/Packages/libssh-devel-0.9.4-2.el8.x86_64.rpm
+
+    - name: Install static build requirements
+      run: dnf builddep --assumeyes --spec packaging/rpm/ansible-pylibssh.spec
+
+    - name: Fetch sources and patches on a community distro
+      if: >-
+        !contains(matrix.target-container.tag, 'ubi')
+      run: spectool --all --get-files --sourcedir packaging/rpm/ansible-pylibssh.spec
+
+    - name: Resolve and install dynamic build deps and build an SRPM on Fedora
+      # Ref: https://github.com/rpm-software-management/rpm/commit/58dcfdd
+      if: contains(matrix.target-container.tag, 'fedora')
+      run: |
+        while :
+        do
+          set +e
+          rpmbuild -br packaging/rpm/ansible-pylibssh.spec
+          [ "$?" -ne 11 ] && break
+          set -e
+          dnf builddep --assumeyes \
+            $HOME/rpmbuild/SRPMS/python-ansible-pylibssh-${{
+                needs.pre-setup.outputs.dist_version
+            }}-1.fc34.buildreqs.nosrc.rpm
+        done
+
+    - name: Build an SRPM on RHELish
+      if: >-
+        !contains(matrix.target-container.tag, 'fedora')
+      run: >-
+        rpmbuild
+        ${{
+            contains(matrix.target-container.tag, 'ubi')
+            && '--undefine=_disable_source_fetch'
+            || ''
+        }}
+        -bs
+        packaging/rpm/ansible-pylibssh.spec
+
+    - name: Build binary RPMs
+      run: >-
+        rpmbuild
+        --rebuild
+        $HOME/rpmbuild/SRPMS/python-ansible-pylibssh-${{
+            needs.pre-setup.outputs.dist_version
+        }}-1.${{
+            contains(matrix.target-container.tag, 'fedora')
+            && 'fc34'
+            || 'el8'
+        }}.src.rpm
+    - name: Install the packaged binary RPM on the system
+      run: >-
+        dnf
+        install
+        --assumeyes
+        $HOME/rpmbuild/RPMS/x86_64/python3-ansible-pylibssh-${{
+            needs.pre-setup.outputs.dist_version
+        }}-1.${{
+            contains(matrix.target-container.tag, 'fedora')
+            && 'fc34'
+            || 'el8'
+        }}.x86_64.rpm
+
+    - name: Smoke-test the installed library
+      run: >-
+        python3 -c
+        'from pylibsshext.session import Session; print(Session())'
+    - name: Produce artifact name
+      id: artifact-name
+      run: >-
+        normalized_container_id=$(
+            echo '${{ matrix.target-container.tag }}' | sed 's#[.\/:]#--#g'
+        );
+        echo "::set-output name=artifact-id::${normalized_container_id}"
+    - name: Store RPM and SRPM as artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ steps.artifact-name.outputs.artifact-id }}--srpm-n-rpm
+        path: |
+          ~/rpmbuild/SRPMS/
+          ~/rpmbuild/RPMS/
+
   test-matrix:
     name: >-
       Test 🐍

--- a/docs/changelog-fragments/205.misc.rst
+++ b/docs/changelog-fragments/205.misc.rst
@@ -1,0 +1,1 @@
+Added an initial RPM spec continuously tested in the CI -- :user:`webknjaz`

--- a/packaging/rpm/ansible-pylibssh.spec
+++ b/packaging/rpm/ansible-pylibssh.spec
@@ -1,0 +1,165 @@
+%global pypi_name ansible-pylibssh
+%global python_importable_name pylibsshext
+# RHEL or CentOS:
+%if 0%{?rhel}
+%global normalized_dist_name ansible_pylibssh
+%global whl_glob %{normalized_dist_name}-%{version}-cp3*-cp3*-linux_%{_arch}.whl
+%endif
+
+Name:    python-%{pypi_name}
+Version: 0.2.0
+Release: 1%{?dist}
+Summary: Python bindings for libssh client specific to Ansible use case
+
+#BuildRoot: %%{_tmppath}/%%{name}-%%{version}-%%{release}-buildroot
+License: LGPL-2+
+URL:     https://github.com/ansible/pylibssh
+Source0: %{pypi_source}
+Source1: %{pypi_source expandvars 0.7.0}
+# RHEL or CentOS:
+%if 0%{?rhel}
+Source2: %{pypi_source build 0.3.1.post1}
+Source3: %{pypi_source Cython 0.29.23}
+Source4: %{pypi_source packaging 20.9}
+Source5: %{pypi_source setuptools 56.0.0}
+Source6: %{pypi_source setuptools_scm 6.0.1}
+Source7: %{pypi_source setuptools_scm_git_archive 1.1}
+Source8: %{pypi_source toml 0.10.2}
+Source9: %{pypi_source pep517 0.10.0}
+Source10: %{pypi_source pip 21.1.1}
+Source11: %{pypi_source pyparsing 2.4.7}
+# RHEL specifically, not CentOS:
+%if 0%{?centos} == 0
+Source12: %{pypi_source importlib_metadata 4.0.1}
+Source13: %{pypi_source zipp 3.4.1}
+Source14: %{pypi_source typing_extensions 3.10.0.0}
+%endif
+%endif
+
+BuildRequires: gcc
+
+BuildRequires: libssh-devel
+BuildRequires: python3-devel
+
+# RHEL or CentOS:
+%if 0%{?rhel}
+BuildRequires: python3dist(pip)
+BuildRequires: python3dist(wheel)
+# CentOS, not RHEL:
+%if 0%{?centos}
+BuildRequires: python3dist(importlib-metadata)
+%endif
+%endif
+# Fedora:
+%if 0%{?fedora}
+# `pyproject-rpm-macros` provides %%pyproject_buildrequires
+BuildRequires: pyproject-rpm-macros
+
+# `python3-toml` is not retrieved by %%pyproject_buildrequires for some reason
+BuildRequires: python3-toml
+%endif
+
+Requires: libssh >= 0.9.0
+
+%description
+$summary
+
+
+# Stolen from https://src.fedoraproject.org/rpms/python-pep517/blob/rawhide/f/python-pep517.spec#_25
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+$summary
+
+%prep
+%autosetup -n %{pypi_name}-%{version}
+
+# Fedora:
+%if 0%{?fedora}
+sed -i '/"expandvars",/d' pyproject.toml
+%endif
+
+%{__python3} -m pip install --no-deps -t bin %{SOURCE1}
+
+# RHEL or CentOS:
+%if 0%{?rhel}
+%{__python3} -m pip install --no-deps -t bin %{SOURCE9}
+%{__python3} -m pip install --no-deps -t bin %{SOURCE2}
+%{__python3} -m pip install --no-deps -t bin %{SOURCE10}
+%{__python3} -m pip install --no-deps -t bin  %{SOURCE3} --install-option="--no-cython-compile"
+%{__python3} -m pip install --no-deps -t bin %{SOURCE4}
+%{__python3} -m pip install --no-deps -t bin %{SOURCE5}
+PYTHONPATH=bin/ %{__python3} -m pip install --no-deps -t bin %{SOURCE6}
+%{__python3} -m pip install --no-deps -t bin %{SOURCE7}
+%{__python3} -m pip install --no-deps -t bin %{SOURCE8}
+%{__python3} -m pip install --no-deps -t bin %{SOURCE11}
+# RHEL specifically, not CentOS:
+%if 0%{?centos} == 0
+PYTHONPATH=bin/ %{__python3} -m pip install --no-deps -t bin %{SOURCE12}
+PYTHONPATH=bin/ %{__python3} -m pip install --no-deps -t bin %{SOURCE13}
+%{__python3} -m pip install --no-deps -t bin %{SOURCE14}
+%endif
+%endif
+
+# Fedora:
+%if 0%{?fedora}
+%generate_buildrequires
+%pyproject_buildrequires
+%endif
+
+
+%build
+
+# Fedora:
+%if 0%{?fedora}
+%pyproject_wheel %{python_importable_name}
+%endif
+
+# RHEL or CentOS:
+%if 0%{?rhel}
+PYTHONPATH=bin/ \
+%{__python3} \
+  -m build \
+  --wheel \
+  --skip-dependencies \
+  --no-isolation \
+  .
+%endif
+
+
+%install
+
+# Fedora:
+%if 0%{?fedora}
+%pyproject_install
+%pyproject_save_files "%{python_importable_name}"
+%endif
+
+# RHEL or CentOS:
+%if 0%{?rhel}
+%{py3_install_wheel %{whl_glob}}
+# Set the installer to rpm so that pip knows not to manage this dist:
+sed \
+  -i 's/pip/rpm/' \
+  %{buildroot}%{python3_sitearch}/%{normalized_dist_name}-%{version}.dist-info/INSTALLER
+%endif
+
+
+%check
+
+
+%files -n python3-%{pypi_name} %{?fedora:-f %{pyproject_files}}
+%license LICENSE.rst
+%doc README.rst
+
+# RHEL or CentOS
+%if 0%{?rhel}
+# NOTE: %%{python3_sitelib} points to /lib/ while %%{python3_sitearch}
+# NOTE: points to /lib64/ when necessary.
+%{python3_sitearch}/%{python_importable_name}
+%{python3_sitearch}/%{normalized_dist_name}-%{version}.dist-info
+%endif
+
+%changelog


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This patch adds a spec file for packaging RPMs compatible with RHEL8+, CentOS8+, and Fedora. It implements CI builds for continuous verifiability.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Packaging Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->