### PR TITLE
Produce single-platform tagged manylinux wheels

### DIFF
--- a/build-scripts/build-manylinux-wheels.sh
+++ b/build-scripts/build-manylinux-wheels.sh
@@ -126,7 +126,7 @@ done
 for PY in $PYTHONS; do
     for whl in ${ORIG_WHEEL_DIR}/${DIST_NAME}-*-${PY}-linux_${ARCH}.whl; do
         >&2 echo Reparing "${whl}" for "${MANYLINUX_TARGET}"...
-        auditwheel repair --plat "${MANYLINUX_TARGET}" "${whl}" -w ${MANYLINUX_DIR}
+        auditwheel repair --only-plat --plat "${MANYLINUX_TARGET}" "${whl}" -w ${MANYLINUX_DIR}
     done
 done
 

--- a/docs/changelog-fragments/224.misc.rst
+++ b/docs/changelog-fragments/224.misc.rst
@@ -1,0 +1,2 @@
+Made ``auditwheel`` only keep one platform tag in the produced wheel
+names -- :user:`webknjaz`


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Make `auditwheel repair` produce wheels with a single tag. This is available since v4.0.0.0b1.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Packaging Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
https://github.com/pypa/auditwheel/pull/289
