### PR TITLE
Update pip ref in the installation guide

### DIFF
--- a/docs/changelog-fragments/225.doc.rst
+++ b/docs/changelog-fragments/225.doc.rst
@@ -1,0 +1,2 @@
+Correct a link to the pip upgrade doc in our installation guide
+-- :user:`webknjaz`

--- a/docs/installation_guide.rst
+++ b/docs/installation_guide.rst
@@ -38,8 +38,8 @@ It should be enough for you to just have Python 2.7 or
     Python package distributions from PyPI and will try to
     fall back to building it from source which would require
     more extra dependencies to succeed.
-    You can upgrade by following :std:ref:`pip's upgrade
-    instructions <pip:upgrading pip>`.
+    You can upgrade by following :std:doc:`pip's upgrade
+    instructions <pip:user_guide>`.
 
 To install |project|, just run:
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This is necessary because various labels and document names got lost
as a result of the recent refactoring of the pip docs:


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
https://github.com/pypa/pip/pull/10009/files#r637937254