### PR TITLE
Expect aliased manylinux tags after repair

### DIFF
--- a/build-scripts/build-manylinux-wheels.sh
+++ b/build-scripts/build-manylinux-wheels.sh
@@ -12,8 +12,11 @@ PYTHON_TARGET="${2}"
 
 set -Eeuo pipefail
 
-source get-static-deps-dir.sh
-source activate-userspace-tools.sh
+THIS_SCRIPT_DIR_PATH=$(dirname "$(readlink -m $(type -p "${0}"))")
+IMAGE_SCRIPTS_DIR_PATH="${THIS_SCRIPT_DIR_PATH}/manylinux-container-image"
+
+source "${IMAGE_SCRIPTS_DIR_PATH}/get-static-deps-dir.sh"
+source "${IMAGE_SCRIPTS_DIR_PATH}/activate-userspace-tools.sh"
 
 SRC_DIR=/io
 PERM_REF_HOST_FILE="${SRC_DIR}/setup.cfg"
@@ -45,6 +48,13 @@ fi
 echo "${PYTHONS}" | >&2 tr ' ' '\n'
 
 
+MANYLINUX_TAG="$(
+    /opt/python/cp39-cp39/bin/python \
+    "${IMAGE_SCRIPTS_DIR_PATH}/manylinux-mapping.py" \
+    "${MANYLINUX_TARGET}"
+)"
+
+
 # Avoid creation of __pycache__/*.py[c|o]
 export PYTHONDONTWRITEBYTECODE=1
 
@@ -57,7 +67,7 @@ then
 fi
 GIT_GLOBAL_ARGS="--git-dir=${SRC_DIR}/.git --work-tree=${SRC_DIR}"
 TESTS_SRC_DIR="${SRC_DIR}/tests"
-BUILD_DIR=$(mktemp -d "/tmp/${DIST_NAME}-${MANYLINUX_TARGET}-build.XXXXXXXXXX")
+BUILD_DIR=$(mktemp -d "/tmp/${DIST_NAME}-${MANYLINUX_TAG}-build.XXXXXXXXXX")
 TESTS_DIR="${BUILD_DIR}/tests"
 STATIC_DEPS_PREFIX="$(get_static_deps_dir)"
 
@@ -125,7 +135,7 @@ done
 # Bundle external shared libraries into the wheels
 for PY in $PYTHONS; do
     for whl in ${ORIG_WHEEL_DIR}/${DIST_NAME}-*-${PY}-linux_${ARCH}.whl; do
-        >&2 echo Reparing "${whl}" for "${MANYLINUX_TARGET}"...
+        >&2 echo Reparing "${whl}" for "${MANYLINUX_TAG}"...
         auditwheel repair --plat "${MANYLINUX_TARGET}" "${whl}" -w ${MANYLINUX_DIR}
     done
 done
@@ -138,7 +148,7 @@ done
 >&2 echo =========================
 >&2 echo
 for PY in $PYTHONS; do
-    for WHEEL_FILE in `ls ${MANYLINUX_DIR}/${DIST_NAME}-*-${PY}-${MANYLINUX_TARGET}.whl`; do
+    for WHEEL_FILE in `ls ${MANYLINUX_DIR}/${DIST_NAME}-*-${PY}-${MANYLINUX_TAG}.whl`; do
         PIP_BIN="/opt/python/${PY}/bin/pip"
         >&2 echo Downloading ${WHEEL_FILE} deps using ${PIP_BIN}...
         ${PIP_BIN} download -d "${WHEEL_DEP_DIR}" "${WHEEL_FILE}" ${PIP_GLOBAL_ARGS}
@@ -151,7 +161,7 @@ done
 >&2 echo ===================
 >&2 echo
 for PY in $PYTHONS; do
-    VENV_NAME="${PY}-${MANYLINUX_TARGET}"
+    VENV_NAME="${PY}-${MANYLINUX_TAG}"
     VENV_PATH="${VENVS_DIR}/${VENV_NAME}"
     VENV_BIN="/opt/python/${PY}/bin/virtualenv"
 
@@ -168,7 +178,7 @@ done
 >&2 echo ============================
 >&2 echo
 for PY in $PYTHONS; do
-    VENV_NAME="${PY}-${MANYLINUX_TARGET}"
+    VENV_NAME="${PY}-${MANYLINUX_TAG}"
     VENV_PATH="${VENVS_DIR}/${VENV_NAME}"
     PIP_BIN="${VENV_PATH}/bin/pip"
     >&2 echo Using ${PIP_BIN}...
@@ -182,7 +192,7 @@ done
 >&2 echo
 for PY in $PYTHONS; do
     WHEEL_BIN="/opt/python/${PY}/bin/wheel"
-    PLAT_TAG="${PY}-${MANYLINUX_TARGET}"
+    PLAT_TAG="${PY}-${MANYLINUX_TAG}"
     UNPACKED_DIR=${UNPACKED_WHEELS_DIR}/${PLAT_TAG}
     WHEEL_FILE=`ls ${MANYLINUX_DIR}/${DIST_NAME}-*-${PLAT_TAG}.whl`
     >&2 echo
@@ -223,6 +233,6 @@ popd
 chown -R --reference="${PERM_REF_HOST_FILE}" "${MANYLINUX_DIR}"/*
 mkdir -pv "${WHEELHOUSE_DIR}"
 chown --reference="${PERM_REF_HOST_FILE}" "${WHEELHOUSE_DIR}"
-cp -av "${MANYLINUX_DIR}"/"${DIST_NAME}"-*-${MANYLINUX_TARGET}.whl "${WHEELHOUSE_DIR}/"
+cp -av "${MANYLINUX_DIR}"/"${DIST_NAME}"-*-${MANYLINUX_TAG}.whl "${WHEELHOUSE_DIR}/"
 >&2 echo Final OS-specific wheels for ${DIST_NAME}:
 ls -l ${WHEELHOUSE_DIR}

--- a/build-scripts/manylinux-container-image/manylinux-mapping.py
+++ b/build-scripts/manylinux-container-image/manylinux-mapping.py
@@ -1,0 +1,37 @@
+#! /usr/bin/env python3.9
+
+import platform
+import sys
+
+
+ARCH = platform.machine()
+
+
+ML_LEGACY_TO_MODERN_MAP = {
+    '_'.join(('manylinux1', ARCH)): 'manylinux_2_5',
+    '_'.join(('manylinux2010', ARCH)): 'manylinux_2_12',
+    '_'.join(('manylinux2014', ARCH)): 'manylinux_2_17',
+}
+
+
+def to_modern_manylinux_tag(legacy_manylinux_tag):
+    return '_'.join((
+        ML_LEGACY_TO_MODERN_MAP.get(
+            legacy_manylinux_tag,
+            legacy_manylinux_tag,
+        ),
+        ARCH,
+    ))
+
+
+def make_aliased_manylinux_tag(manylinux_tag):
+    modern_tag = to_modern_manylinux_tag(manylinux_tag)
+
+    if modern_tag != manylinux_tag:
+        manylinux_tag = '.'.join((modern_tag, manylinux_tag))
+
+    return manylinux_tag
+
+
+if __name__ == '__main__':
+    print(make_aliased_manylinux_tag(sys.argv[1]))

--- a/docs/changelog-fragments/226.misc.rst
+++ b/docs/changelog-fragments/226.misc.rst
@@ -1,0 +1,3 @@
+Improved manylinux build scripts to expect dual-aliased manylinux tags
+produced for versions 1/2010/2014 along with their :pep:`600`
+counterparts after ``auditwheel repair`` -- :user:`webknjaz`


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This change patches the platform-specific wheel build script to expect dual-aliased manylinux tags produced for versions 1/2010/2014 along with their PEP 600 counterparts.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Packaging Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
https://www.python.org/dev/peps/pep-0600/