### PR TITLE
simplify packit.yaml: followup to #227

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -19,6 +19,8 @@ actions:
     -- 
     --sdist
     --outdir packaging/rpm/
+  - mkdir -p dist/
+  - sh -c 'ln -s ../packaging/rpm/"${PACKIT_PROJECT_NAME_VERSION}".tar.gz dist/"${PACKIT_PROJECT_NAME_VERSION}".tar.gz'
   - sh -c 'echo packaging/rpm/"${PACKIT_PROJECT_NAME_VERSION}".tar.gz'
   # create-patches:
   # fix-spec-file:

--- a/.packit.yml
+++ b/.packit.yml
@@ -1,10 +1,11 @@
 ---
 actions:
-  create-archive:
+  post-upstream-clone:
   - >-
     python3 -m
     pip install setuptools_scm tox
     --user
+  create-archive:
   - >-
     bash -c '
     spectool
@@ -22,10 +23,6 @@ actions:
   # create-patches:
   # fix-spec-file:
   get-current-version:
-  - >-
-    python3 -m
-    pip install setuptools_scm
-    --user
   - sh -c "python3 -m setuptools_scm | awk '{print $3}'"
   # post-upstream-clone:
 # allowed_gpg_keys:

--- a/.packit.yml
+++ b/.packit.yml
@@ -9,7 +9,7 @@ actions:
   - >-
     bash -c '
     spectool
-    --define "upstream_version ${PACKIT_PROJECT_NAME_VERSION}"
+    --define "upstream_version ${PACKIT_PROJECT_VERSION}"
     --all --get-files
     --sourcedir packaging/rpm/ansible-pylibssh.spec
     '

--- a/.packit.yml
+++ b/.packit.yml
@@ -8,6 +8,8 @@ actions:
     -- 
     --sdist
     --outdir packaging/rpm/
+  - mkdir -pv dist
+  - sh -c 'ln -sv packaging/rpm/"${PACKIT_PROJECT_NAME_VERSION}".tar.gz dist/'
   - sh -c 'echo packaging/rpm/"${PACKIT_PROJECT_NAME_VERSION}".tar.gz'
   create-patches:
   - spectool --all --get-files --sourcedir packaging/rpm/ansible-pylibssh.spec

--- a/.packit.yml
+++ b/.packit.yml
@@ -1,0 +1,45 @@
+---
+# actions:
+#   create-archive:
+#   create-patches:
+#   fix-spec-file:
+#   get-current-version:
+#   post-upstream-clone:
+# allowed_gpg_keys:
+# - 5DE3E0509C47EA3CF04A42D34AEE18F83AFDEB23  # GH web UI commit signing key
+archive_root_dir_template: >-
+  {upstream_pkg_name}-{version}
+copy_upstream_release_description: false
+create_pr: true  # in dist-git
+dist_git_base_url: https://src.fedoraproject.org/
+dist_git_namespace: rpms
+downstream_package_name: python3-ansible-pylibssh
+jobs:
+- job: copr_build
+  trigger: pull_request
+  metadata:
+    targets:
+    # - fedora-all
+    - fedora-stable
+- job: tests
+  trigger: pull_request
+  metadata:
+    targets: fedora-stable
+- job: propose_downstream
+  trigger: release
+  metadata:
+    dist_git_branches: fedora-all
+notifications:
+  pull_request:
+    successful_build: true
+patch_generation_ignore_paths: []
+patch_generation_patch_id_digits: 4
+sources: []
+specfile_path: packaging/rpm/ansible-pylibssh.spec  # defaults to $downstream_package_name.spec if downstream_package_name is set.
+# spec_source_id: 0
+sync_changelog: false
+# synced_files: []
+upstream_package_name: ansible-pylibssh
+upstream_project_url: https://github.com/ansible/pylibssh
+upstream_tag_template: v{version}
+...

--- a/.packit.yml
+++ b/.packit.yml
@@ -17,7 +17,15 @@ actions:
   - ls dist/*.tar.gz
 #   create-patches:
 #   fix-spec-file:
-#   get-current-version:
+  get-current-version:
+  - >-
+    python3 -m
+    pip install setuptools_scm
+    --user
+  - >-
+    python3 -m setuptools_scm
+    |
+    awk '{print $3}'
 #   post-upstream-clone:
 # allowed_gpg_keys:
 # - 5DE3E0509C47EA3CF04A42D34AEE18F83AFDEB23  # GH web UI commit signing key

--- a/.packit.yml
+++ b/.packit.yml
@@ -17,7 +17,17 @@ actions:
     --user
   - sh -c "python3 -m setuptools_scm | awk '{print $3}'"
   post-upstream-clone:
-  - spectool --all --get-files --sourcedir packaging/rpm/ansible-pylibssh.spec
+  - >-
+    python3 -m
+    pip install setuptools_scm
+    --user
+  - >-
+    bash -c "
+    spectool
+    --define "'"'"upstream_version $(python3 -m setuptools_scm | awk '{print $3}')"'"'"
+    --all --get-files
+    --sourcedir packaging/rpm/ansible-pylibssh.spec
+    "
 # allowed_gpg_keys:
 # - 5DE3E0509C47EA3CF04A42D34AEE18F83AFDEB23  # GH web UI commit signing key
 archive_root_dir_template: >-

--- a/.packit.yml
+++ b/.packit.yml
@@ -14,6 +14,8 @@ actions:
   - sh -c 'cd packaging/rpm/dist/; ln -sv ../"${PACKIT_PROJECT_NAME_VERSION}".tar.gz'
   - sh -c 'echo packaging/rpm/"${PACKIT_PROJECT_NAME_VERSION}".tar.gz'
   create-patches:
+  - pwd
+  - ls -alh
   - spectool --all --get-files --sourcedir packaging/rpm/ansible-pylibssh.spec
 #   fix-spec-file:
   get-current-version:

--- a/.packit.yml
+++ b/.packit.yml
@@ -12,6 +12,7 @@ actions:
   - sh -c 'ln -sv packaging/rpm/"${PACKIT_PROJECT_NAME_VERSION}".tar.gz dist/'
   - mkdir -pv packaging/rpm/dist/
   - sh -c 'cd packaging/rpm/dist/; ln -sv ../"${PACKIT_PROJECT_NAME_VERSION}".tar.gz'
+  - ls -alh dist/ packaging/rpm/dist/ packaging/rpm/
   - sh -c 'echo packaging/rpm/"${PACKIT_PROJECT_NAME_VERSION}".tar.gz'
   create-patches:
   - pwd

--- a/.packit.yml
+++ b/.packit.yml
@@ -1,6 +1,13 @@
 ---
-# actions:
-#   create-archive:
+actions:
+  create-archive:
+  - dnf install -y python3-tox
+  - >-
+    python3 -m
+    tox -e build-dists
+    -- 
+    --sdist
+  - ls dist/*.tar.gz
 #   create-patches:
 #   fix-spec-file:
 #   get-current-version:

--- a/.packit.yml
+++ b/.packit.yml
@@ -7,7 +7,8 @@ actions:
     tox -e build-dists
     -- 
     --sdist
-  - sh -c 'echo dist/"${PACKIT_PROJECT_NAME_VERSION}".tar.gz'
+    --outdir packaging/rpm/
+  - sh -c 'echo packaging/rpm/"${PACKIT_PROJECT_NAME_VERSION}".tar.gz'
   create-patches:
   - spectool --all --get-files --sourcedir packaging/rpm/ansible-pylibssh.spec
 #   fix-spec-file:

--- a/.packit.yml
+++ b/.packit.yml
@@ -10,11 +10,12 @@ actions:
     tox -e build-dists
     -- 
     --sdist
-  - echo "${PACKIT_PROJECT_NAME_VERSION}"
-  - echo "${PACKIT_PROJECT_VERSION}"
+  - sh -c 'echo "${PACKIT_PROJECT_NAME_VERSION}"'
+  - sh -c 'echo "${PACKIT_PROJECT_VERSION}"'
   - ls
   - ls dist/
-  - ls dist/*.tar.gz
+  - sh -c 'ls dist/*.tar.gz'
+  - sh -c 'ls dist/"${PACKIT_PROJECT_NAME_VERSION}".tar.gz'
 #   create-patches:
 #   fix-spec-file:
   get-current-version:
@@ -22,10 +23,7 @@ actions:
     python3 -m
     pip install setuptools_scm
     --user
-  - >-
-    python3 -m setuptools_scm
-    |
-    awk '{print $3}'
+  - sh -c "python3 -m setuptools_scm | awk '{print $3}'"
 #   post-upstream-clone:
 # allowed_gpg_keys:
 # - 5DE3E0509C47EA3CF04A42D34AEE18F83AFDEB23  # GH web UI commit signing key

--- a/.packit.yml
+++ b/.packit.yml
@@ -10,6 +10,8 @@ actions:
     --outdir packaging/rpm/
   - mkdir -pv dist
   - sh -c 'ln -sv packaging/rpm/"${PACKIT_PROJECT_NAME_VERSION}".tar.gz dist/'
+  - mkdir -pv packaging/rpm/dist/
+  - sh -c 'cd packaging/rpm/dist/; ln -sv ../"${PACKIT_PROJECT_NAME_VERSION}".tar.gz'
   - sh -c 'echo packaging/rpm/"${PACKIT_PROJECT_NAME_VERSION}".tar.gz'
   create-patches:
   - spectool --all --get-files --sourcedir packaging/rpm/ansible-pylibssh.spec

--- a/.packit.yml
+++ b/.packit.yml
@@ -1,12 +1,19 @@
 ---
 actions:
   create-archive:
-  - dnf install -y python3-tox
+  - >-
+    python3 -m
+    pip install tox
+    --user
   - >-
     python3 -m
     tox -e build-dists
     -- 
     --sdist
+  - echo "${PACKIT_PROJECT_NAME_VERSION}"
+  - echo "${PACKIT_PROJECT_VERSION}"
+  - ls
+  - ls dist/
   - ls dist/*.tar.gz
 #   create-patches:
 #   fix-spec-file:

--- a/.packit.yml
+++ b/.packit.yml
@@ -14,29 +14,29 @@ actions:
   - sh -c 'cd packaging/rpm/dist/; ln -sv ../"${PACKIT_PROJECT_NAME_VERSION}".tar.gz'
   - ls -alh dist/ packaging/rpm/dist/ packaging/rpm/
   - sh -c 'echo packaging/rpm/"${PACKIT_PROJECT_NAME_VERSION}".tar.gz'
-  create-patches:
-  - pwd
-  - ls -alh
-  - spectool --all --get-files --sourcedir packaging/rpm/ansible-pylibssh.spec
-#   fix-spec-file:
+  # create-patches:
+  # - pwd
+  # - ls -alh
+  # - spectool --all --get-files --sourcedir packaging/rpm/ansible-pylibssh.spec
+# fix-spec-file:
   get-current-version:
   - >-
     python3 -m
     pip install setuptools_scm
     --user
   - sh -c "python3 -m setuptools_scm | awk '{print $3}'"
-  # post-upstream-clone:
-  # - >-
-  #   python3 -m
-  #   pip install setuptools_scm
-  #   --user
-  # - >-
-  #   bash -c "
-  #   spectool
-  #   --define "'"'"upstream_version $(python3 -m setuptools_scm | awk '{print $3}')"'"'"
-  #   --all --get-files
-  #   --sourcedir packaging/rpm/ansible-pylibssh.spec
-  #   "
+  post-upstream-clone:
+  - >-
+    python3 -m
+    pip install setuptools_scm
+    --user
+  - >-
+    bash -c "
+    spectool
+    --define "'"'"upstream_version $(python3 -m setuptools_scm | awk '{print $3}')"'"'"
+    --all --get-files
+    --sourcedir packaging/rpm/ansible-pylibssh.spec
+    "
 # allowed_gpg_keys:
 # - 5DE3E0509C47EA3CF04A42D34AEE18F83AFDEB23  # GH web UI commit signing key
 archive_root_dir_template: >-

--- a/.packit.yml
+++ b/.packit.yml
@@ -16,7 +16,8 @@ actions:
     pip install setuptools_scm
     --user
   - sh -c "python3 -m setuptools_scm | awk '{print $3}'"
-#   post-upstream-clone:
+  post-upstream-clone:
+  - spectool --all --get-files --sourcedir packaging/rpm/ansible-pylibssh.spec
 # allowed_gpg_keys:
 # - 5DE3E0509C47EA3CF04A42D34AEE18F83AFDEB23  # GH web UI commit signing key
 archive_root_dir_template: >-

--- a/.packit.yml
+++ b/.packit.yml
@@ -8,7 +8,8 @@ actions:
     -- 
     --sdist
   - sh -c 'echo dist/"${PACKIT_PROJECT_NAME_VERSION}".tar.gz'
-#   create-patches:
+  create-patches:
+  - spectool --all --get-files --sourcedir packaging/rpm/ansible-pylibssh.spec
 #   fix-spec-file:
   get-current-version:
   - >-
@@ -16,18 +17,18 @@ actions:
     pip install setuptools_scm
     --user
   - sh -c "python3 -m setuptools_scm | awk '{print $3}'"
-  post-upstream-clone:
-  - >-
-    python3 -m
-    pip install setuptools_scm
-    --user
-  - >-
-    bash -c "
-    spectool
-    --define "'"'"upstream_version $(python3 -m setuptools_scm | awk '{print $3}')"'"'"
-    --all --get-files
-    --sourcedir packaging/rpm/ansible-pylibssh.spec
-    "
+  # post-upstream-clone:
+  # - >-
+  #   python3 -m
+  #   pip install setuptools_scm
+  #   --user
+  # - >-
+  #   bash -c "
+  #   spectool
+  #   --define "'"'"upstream_version $(python3 -m setuptools_scm | awk '{print $3}')"'"'"
+  #   --all --get-files
+  #   --sourcedir packaging/rpm/ansible-pylibssh.spec
+  #   "
 # allowed_gpg_keys:
 # - 5DE3E0509C47EA3CF04A42D34AEE18F83AFDEB23  # GH web UI commit signing key
 archive_root_dir_template: >-

--- a/.packit.yml
+++ b/.packit.yml
@@ -1,21 +1,13 @@
 ---
 actions:
   create-archive:
-  - >-
-    python3 -m
-    pip install tox
-    --user
+  - python3 -m pip install tox --user
   - >-
     python3 -m
     tox -e build-dists
     -- 
     --sdist
-  - sh -c 'echo "${PACKIT_PROJECT_NAME_VERSION}"'
-  - sh -c 'echo "${PACKIT_PROJECT_VERSION}"'
-  - ls
-  - ls dist/
-  - sh -c 'ls dist/*.tar.gz'
-  - sh -c 'ls dist/"${PACKIT_PROJECT_NAME_VERSION}".tar.gz'
+  - sh -c 'echo dist/"${PACKIT_PROJECT_NAME_VERSION}".tar.gz'
 #   create-patches:
 #   fix-spec-file:
   get-current-version:

--- a/.packit.yml
+++ b/.packit.yml
@@ -7,7 +7,7 @@ actions:
     tox -e build-dists
     -- 
     --sdist
-  - sh -c 'echo dist/"${PACKIT_PROJECT_NAME_VERSION}".tar.gz'
+  - echo dist/"${PACKIT_PROJECT_NAME_VERSION}".tar.gz
   create-patches:
   - spectool --all --get-files --sourcedir packaging/rpm/ansible-pylibssh.spec
 #   fix-spec-file:

--- a/.packit.yml
+++ b/.packit.yml
@@ -7,7 +7,7 @@ actions:
     tox -e build-dists
     -- 
     --sdist
-  - echo dist/"${PACKIT_PROJECT_NAME_VERSION}".tar.gz
+  - sh -c 'echo dist/"${PACKIT_PROJECT_NAME_VERSION}".tar.gz'
   create-patches:
   - spectool --all --get-files --sourcedir packaging/rpm/ansible-pylibssh.spec
 #   fix-spec-file:

--- a/.packit.yml
+++ b/.packit.yml
@@ -19,8 +19,8 @@ actions:
     -- 
     --sdist
     --outdir packaging/rpm/
-  - mkdir -p dist/
-  - sh -c 'ln -s ../packaging/rpm/"${PACKIT_PROJECT_NAME_VERSION}".tar.gz dist/"${PACKIT_PROJECT_NAME_VERSION}".tar.gz'
+  # workaround for https://github.com/packit/packit/issues/1334
+  - sh -c 'mkdir -p dist/ && cp -av packaging/rpm/"${PACKIT_PROJECT_NAME_VERSION}".tar.gz dist/'
   - sh -c 'echo packaging/rpm/"${PACKIT_PROJECT_NAME_VERSION}".tar.gz'
   # create-patches:
   # fix-spec-file:

--- a/.packit.yml
+++ b/.packit.yml
@@ -1,42 +1,33 @@
 ---
 actions:
   create-archive:
-  - python3 -m pip install tox --user
+  - >-
+    python3 -m
+    pip install setuptools_scm tox
+    --user
+  - >-
+    bash -c '
+    spectool
+    --define "upstream_version ${PACKIT_PROJECT_NAME_VERSION}"
+    --all --get-files
+    --sourcedir packaging/rpm/ansible-pylibssh.spec
+    '
   - >-
     python3 -m
     tox -e build-dists
     -- 
     --sdist
     --outdir packaging/rpm/
-  - mkdir -pv dist
-  - sh -c 'ln -sv packaging/rpm/"${PACKIT_PROJECT_NAME_VERSION}".tar.gz dist/'
-  - mkdir -pv packaging/rpm/dist/
-  - sh -c 'cd packaging/rpm/dist/; ln -sv ../"${PACKIT_PROJECT_NAME_VERSION}".tar.gz'
-  - ls -alh dist/ packaging/rpm/dist/ packaging/rpm/
   - sh -c 'echo packaging/rpm/"${PACKIT_PROJECT_NAME_VERSION}".tar.gz'
   # create-patches:
-  # - pwd
-  # - ls -alh
-  # - spectool --all --get-files --sourcedir packaging/rpm/ansible-pylibssh.spec
-# fix-spec-file:
+  # fix-spec-file:
   get-current-version:
   - >-
     python3 -m
     pip install setuptools_scm
     --user
   - sh -c "python3 -m setuptools_scm | awk '{print $3}'"
-  post-upstream-clone:
-  - >-
-    python3 -m
-    pip install setuptools_scm
-    --user
-  - >-
-    bash -c "
-    spectool
-    --define "'"'"upstream_version $(python3 -m setuptools_scm | awk '{print $3}')"'"'"
-    --all --get-files
-    --sourcedir packaging/rpm/ansible-pylibssh.spec
-    "
+  # post-upstream-clone:
 # allowed_gpg_keys:
 # - 5DE3E0509C47EA3CF04A42D34AEE18F83AFDEB23  # GH web UI commit signing key
 archive_root_dir_template: >-

--- a/packaging/rpm/ansible-pylibssh.spec
+++ b/packaging/rpm/ansible-pylibssh.spec
@@ -2,7 +2,7 @@
 
 # NOTE: The target version may be set dynamically via
 # NOTE: rpmbuild --define "upstream_version 0.2.1.dev125+g0b5bde0"
-%global upstream_version_fallback %(ls -t dist/%{pypi_name}-*.tar.gz packaging/rpm/%{pypi_name}-*.tar.gz | head -n 1 | sed 's#^\\(dist|packaging\\)\\/rpm\\/%{pypi_name}-\\(.*\\)\\.tar\\.gz$#\\1#')
+%global upstream_version_fallback %(ls -t dist/%{pypi_name}-*.tar.gz | head -n 1 | sed 's#^dist\\/%{pypi_name}-\\(.*\\)\\.tar\\.gz$#\\1#')
 # If "upstream_version" macro is unset, use the fallback defined above:
 %if "%{!?upstream_version:UNSET}" == "UNSET"
 %global upstream_version %{upstream_version_fallback}

--- a/packaging/rpm/ansible-pylibssh.spec
+++ b/packaging/rpm/ansible-pylibssh.spec
@@ -2,7 +2,7 @@
 
 # NOTE: The target version may be set dynamically via
 # NOTE: rpmbuild --define "upstream_version 0.2.1.dev125+g0b5bde0"
-%global upstream_version_fallback %(ls -t dist/%{pypi_name}-*.tar.gz | head -n 1 | sed 's#^dist\\/%{pypi_name}-\\(.*\\)\\.tar\\.gz$#\\1#')
+%global upstream_version_fallback %(ls -t dist/%{pypi_name}-*.tar.gz packaging/rpm/%{pypi_name}-*.tar.gz | head -n 1 | sed 's#^\\(dist|packaging\\)\\/rpm\\/%{pypi_name}-\\(.*\\)\\.tar\\.gz$#\\1#')
 # If "upstream_version" macro is unset, use the fallback defined above:
 %if "%{!?upstream_version:UNSET}" == "UNSET"
 %global upstream_version %{upstream_version_fallback}


### PR DESCRIPTION
most of the opts use the default value so I dropped them

the build will fail 100% because it requires many different dists:
```
error: Bad file: /builddir/build/SOURCES/setuptools_scm_git_archive-1.1.tar.gz: No such file or directory
error: Bad file: /builddir/build/SOURCES/setuptools_scm-6.0.1.tar.gz: No such file or directory
error: Bad file: /builddir/build/SOURCES/setuptools-56.0.0.tar.gz: No such file or directory
error: Bad file: /builddir/build/SOURCES/packaging-20.9.tar.gz: No such file or directory
error: Bad file: /builddir/build/SOURCES/Cython-0.29.23.tar.gz: No such file or directory
error: Bad file: /builddir/build/SOURCES/build-0.3.1.post1.tar.gz: No such file or directory
    Bad file: /builddir/build/SOURCES/coverage-5.5.tar.gz: No such file or directory
    Bad file: /builddir/build/SOURCES/pyparsing-2.4.7.tar.gz: No such file or directory
    Bad file: /builddir/build/SOURCES/py-1.10.0.tar.gz: No such file or directory
    Bad file: /builddir/build/SOURCES/pluggy-0.13.1.tar.gz: No such file or directory
    Bad file: /builddir/build/SOURCES/attrs-20.3.0.tar.gz: No such file or directory
    Bad file: /builddir/build/SOURCES/iniconfig-1.1.1.tar.gz: No such file or directory
    Bad file: /builddir/build/SOURCES/pytest-xdist-2.3.0.tar.gz: No such file or directory
    Bad file: /builddir/build/SOURCES/pytest-forked-1.3.0.tar.gz: No such file or directory
    Bad file: /builddir/build/SOURCES/pytest-cov-2.12.1.tar.gz: No such file or directory
    Bad file: /builddir/build/SOURCES/pytest-6.2.4.tar.gz: No such file or directory
    Bad file: /builddir/build/SOURCES/pyparsing-2.4.7.tar.gz: No such file or directory
    Bad file: /builddir/build/SOURCES/pip-21.1.1.tar.gz: No such file or directory
    Bad file: /builddir/build/SOURCES/pep517-0.10.0.tar.gz: No such file or directory
    Bad file: /builddir/build/SOURCES/toml-0.10.2.tar.gz: No such file or directory
    Bad file: /builddir/build/SOURCES/setuptools_scm_git_archive-1.1.tar.gz: No such file or directory
    Bad file: /builddir/build/SOURCES/setuptools_scm-6.0.1.tar.gz: No such file or directory
    Bad file: /builddir/build/SOURCES/setuptools-56.0.0.tar.gz: No such file or directory
    Bad file: /builddir/build/SOURCES/packaging-20.9.tar.gz: No such file or directory
    Bad file: /builddir/build/SOURCES/Cython-0.29.23.tar.gz: No such file or directory
    Bad file: /builddir/build/SOURCES/build-0.3.1.post1.tar.gz: No such file or directory
```

I can see that in GHA you're using an action to fetch them: something similar would need to be done in packit.yaml:
```
actions:
  post-upstream-clone:
  - curl -sO https://...
```