### PR TITLE
Ignore false positive NAME = "VALUE" failures

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -83,7 +83,7 @@ pytest-parametrize-values-row-type = tuple
 
 # flake8-eradicate
 # E800:
-eradicate-whitelist-extend = distutils:\s+libraries\s+=\s+|isort:\s+\w+
+eradicate-whitelist-extend = distutils:\s+libraries\s+=\s+|isort:\s+\w+|NAME = "VALUE"
 
 # wemake-python-styleguide
 show-source = true

--- a/docs/changelog-fragments/258.misc.rst
+++ b/docs/changelog-fragments/258.misc.rst
@@ -1,0 +1,1 @@
+Added ``NAME = "VALUE"`` to flake8-eradicate whitelist to work around test false positive introduced in flake8-eradicate 1.1.0 -- by :user:`Qalthos`


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This error was introduced in flake8-eradicate 1.1.0 - we could instead
cap the test to less than that version

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Misc Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Ref: https://github.com/wemake-services/flake8-eradicate/issues/215