### PR TITLE
Drop deprecated/EOLed Ubuntu 16 from CI/CD matrix

### DIFF
--- a/.github/workflows/build-test-n-publish.yml
+++ b/.github/workflows/build-test-n-publish.yml
@@ -887,13 +887,9 @@ jobs:
         - ubuntu-20.04
         - macos-latest
         - ubuntu-18.04
-        - ubuntu-16.04
         dist-type:
         - binary
         - source
-        exclude:
-        - dist-type: source
-          runner-vm-os: ubuntu-16.04  # has too old libssh in the repos
 
     env:
       ANSIBLE_PYLIBSSH_TRACING: >-

--- a/docs/changelog-fragments/260.misc.rst
+++ b/docs/changelog-fragments/260.misc.rst
@@ -1,0 +1,2 @@
+Stopped testing ``pylibssh`` binary wheels under Ubuntu 16.04 in GitHub
+Actions CI/CD because it is EOL now -- :user:`webknjaz`


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Ubuntu 16 hit EOL in April. Later, it got deleted from GHA. This patch adjusts the test matrix accordingly.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Testing Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
https://github.com/actions/virtual-environments#available-environments