### PR TITLE
Add `python3-pip` to Fedora RPM spec's build deps

### DIFF
--- a/docs/changelog-fragments/262.misc.rst
+++ b/docs/changelog-fragments/262.misc.rst
@@ -1,0 +1,2 @@
+Declare ``python3-pip`` a build dependency under Fedora fixing the RPM
+creation job in GitHub Actions CI/CD under Fedora -- :user:`webknjaz`

--- a/packaging/rpm/ansible-pylibssh.spec
+++ b/packaging/rpm/ansible-pylibssh.spec
@@ -91,6 +91,9 @@ BuildRequires: python3dist(importlib-metadata)
 # `pyproject-rpm-macros` provides %%pyproject_buildrequires
 BuildRequires: pyproject-rpm-macros
 
+# `python3-pip` is used to install vendored build deps
+BuildRequires: python3-pip
+
 # `python3-toml` is not retrieved by %%pyproject_buildrequires for some reason
 BuildRequires: python3-toml
 %endif


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fedora doesn't have `python3-pip` installed by default which caused the `rpmbuild` process to fail. This patch corrects that by declaring a build dependency in the spec file.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Packaging Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
N/A