### PR TITLE
exec_command segfault partial fix

### DIFF
--- a/docs/changelog-fragments/280.bugfix.rst
+++ b/docs/changelog-fragments/280.bugfix.rst
@@ -1,0 +1,2 @@
+Improved ``channel.exec_command`` to always use a newly created ``ssh_channel`` to avoid
+segfaults on repeated calls -- by :user:`Qalthos`

--- a/src/pylibsshext/channel.pyx
+++ b/src/pylibsshext/channel.pyx
@@ -92,7 +92,7 @@ cdef class Channel:
         else:
             rc = libssh.ssh_channel_poll_timeout(self._libssh_channel, timeout, stderr)
         if rc == libssh.SSH_ERROR:
-            raise LibsshChannelException("Failed to poll channel: [%d]" % rc)
+            raise LibsshChannelException("Failed to poll channel: [{0}]".format(rc))
         return rc
 
     def read_nonblocking(self, size=1024, stderr=0):
@@ -148,13 +148,13 @@ cdef class Channel:
         rc = libssh.ssh_channel_open_session(channel)
         if rc != libssh.SSH_OK:
             libssh.ssh_channel_free(channel)
-            raise LibsshChannelException("Failed to open_session: [%d]" % rc)
+            raise LibsshChannelException("Failed to open_session: [{0}]".format(rc))
 
         rc = libssh.ssh_channel_request_exec(channel, command.encode("utf-8"))
         if rc != libssh.SSH_OK:
             libssh.ssh_channel_close(channel)
             libssh.ssh_channel_free(channel)
-            raise LibsshChannelException("Failed to execute command [%s]: [%d]" % (command, rc))
+            raise LibsshChannelException("Failed to execute command [{0}]: [{1}]".format(command, rc))
         result = CompletedProcess(args=command, returncode=-1, stdout=b'', stderr=b'')
 
         cdef callbacks.ssh_channel_callbacks_struct cb

--- a/src/pylibsshext/includes/libssh.pxd
+++ b/src/pylibsshext/includes/libssh.pxd
@@ -21,7 +21,7 @@ from libc.stdint cimport uint32_t
 
 cdef extern from "libssh/libssh.h" nogil:
 
-    cpdef const char * libssh_version "SSH_STRINGIFY(LIBSSH_VERSION)"
+    cdef const char * libssh_version "SSH_STRINGIFY(LIBSSH_VERSION)"
 
     cdef struct ssh_session_struct:
         pass

--- a/tests/unit/channel_test.py
+++ b/tests/unit/channel_test.py
@@ -32,11 +32,14 @@ def ssh_channel(ssh_client_session):
     'Ref: https://github.com/ansible/pylibssh/issues/57',  # noqa: WPS326
     strict=False,
 )
-@pytest.mark.forked()  # noqa: PT023 -- it's unclear if braces are needed here
+@pytest.mark.forked
 def test_exec_command(ssh_channel):
     """Test getting the output of a remotely executed command."""
     u_cmd_out = ssh_channel.exec_command('echo -n Hello World').stdout.decode()
     assert u_cmd_out == u'Hello World'  # noqa: WPS302
+    # Test that repeated calls to exec_command do not segfault.
+    u_cmd_out = ssh_channel.exec_command('echo -n Hello Again').stdout.decode()
+    assert u_cmd_out == u'Hello Again'  # noqa: WPS302
 
 
 def test_double_close(ssh_channel):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #255 which seems to have mostly been introduced trying to fix #60

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### ADDITIONAL INFORMATION
The issue with #255 is not actually anything to do with line feeds, but rather reusing the internal `libssh_channel`. As mentioned at https://api.libssh.org/stable/libssh_tutor_guided_tour.html#using_ssh under "Doing Something", each call to ssh_channel_request_exec requires a fresh channel.