### PR TITLE
Support specifying socket fd for connection.

### DIFF
--- a/docs/changelog-fragments/343.feature.rst
+++ b/docs/changelog-fragments/343.feature.rst
@@ -1,1 +1,1 @@
-Added support for ``:fd:`` socket option -- by :user:`sabedevops`                                                                                             
+Added support for ``:fd:`` socket option -- by :user:`sabedevops`

--- a/docs/changelog-fragments/343.feature.rst
+++ b/docs/changelog-fragments/343.feature.rst
@@ -1,0 +1,1 @@
+Added support for ``:fd:`` socket option -- by :user:`sabedevops`                                                                                             

--- a/src/pylibsshext/session.pyx
+++ b/src/pylibsshext/session.pyx
@@ -26,6 +26,7 @@ from pylibsshext.sftp import SFTP
 
 
 OPTS_MAP = {
+    "fd": libssh.SSH_OPTIONS_FD,
     "host": libssh.SSH_OPTIONS_HOST,
     "user": libssh.SSH_OPTIONS_USER,
     "port": libssh.SSH_OPTIONS_PORT,
@@ -147,6 +148,7 @@ cdef class Session(object):
             return ret
 
     def set_ssh_options(self, key, value):
+        cdef int value_fd
         cdef int value_int
         cdef unsigned int value_uint
         cdef long value_long
@@ -158,7 +160,10 @@ cdef class Session(object):
             key_m = OPTS_MAP[key]
         else:
             raise LibsshSessionException("Unknown attribute name [%s]" % key)
-        if key == "gssapi_delegate_credentials":
+        if key == "fd":
+            value_fd = value
+            libssh.ssh_options_set(self._libssh_session, key_m, &value_fd)
+        elif key == "gssapi_delegate_credentials":
             value_int = value
             libssh.ssh_options_set(self._libssh_session, key_m, &value_int)
         elif key == "port":
@@ -178,6 +183,9 @@ cdef class Session(object):
         """Conenct to ssh server and negotiate libssh session by
         optionally verifying the server's host key and authenticate
         either by password or private key.
+
+        :param fd: The file descriptor of the socket to use for the connection.
+        :type host: int
 
         :param host: The address of the remote host
         :type host: str

--- a/src/pylibsshext/session.pyx
+++ b/src/pylibsshext/session.pyx
@@ -185,7 +185,7 @@ cdef class Session(object):
         either by password or private key.
 
         :param fd: The file descriptor of the socket to use for the connection.
-        :type host: int
+        :type fd: int
 
         :param host: The address of the remote host
         :type host: str

--- a/src/pylibsshext/session.pyx
+++ b/src/pylibsshext/session.pyx
@@ -148,7 +148,6 @@ cdef class Session(object):
             return ret
 
     def set_ssh_options(self, key, value):
-        cdef int value_fd
         cdef int value_int
         cdef unsigned int value_uint
         cdef long value_long
@@ -160,10 +159,7 @@ cdef class Session(object):
             key_m = OPTS_MAP[key]
         else:
             raise LibsshSessionException("Unknown attribute name [%s]" % key)
-        if key == "fd":
-            value_fd = value
-            libssh.ssh_options_set(self._libssh_session, key_m, &value_fd)
-        elif key == "gssapi_delegate_credentials":
+        if key in ("fd", "gssapi_delegate_credentials"):
             value_int = value
             libssh.ssh_options_set(self._libssh_session, key_m, &value_int)
         elif key == "port":


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The libssh library advertises "[Your sockets: the app hands over the socket, or uses libssh sockets](https://www.libssh.org/features/)".

The pylibssh library should support this capability. With respect to Ansible, it opens the door for new connections plugins to seamlessly operate over different sockets  (like Unix sockets, or  WebSockets) while allowing for code reuse.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```python
import socket

sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
s = Session()
s.connect(fd=sock.fileno())
```
