### PR TITLE
Use absolute paths in the RPM spec's `PYTHONPATH`

### DIFF
--- a/packaging/rpm/ansible-pylibssh.spec
+++ b/packaging/rpm/ansible-pylibssh.spec
@@ -120,35 +120,59 @@ $summary
 sed -i '/"expandvars",/d' pyproject.toml
 %endif
 
+PYTHONPATH="$(pwd)/bin" \
 %{__python3} -m pip install --no-deps -t bin %{SOURCE1}
 
 # RHEL or CentOS:
 %if 0%{?rhel}
+PYTHONPATH="$(pwd)/bin" \
 %{__python3} -m pip install --no-deps -t bin %{SOURCE9}
+PYTHONPATH="$(pwd)/bin" \
 %{__python3} -m pip install --no-deps -t bin %{SOURCE2}
+PYTHONPATH="$(pwd)/bin" \
 %{__python3} -m pip install --no-deps -t bin %{SOURCE10}
+PYTHONPATH="$(pwd)/bin" \
 %{__python3} -m pip install --no-deps -t bin  %{SOURCE3} --install-option="--no-cython-compile"
+PYTHONPATH="$(pwd)/bin" \
 %{__python3} -m pip install --no-deps -t bin %{SOURCE4}
+PYTHONPATH="$(pwd)/bin" \
 %{__python3} -m pip install --no-deps -t bin %{SOURCE5}
-PYTHONPATH=bin/ %{__python3} -m pip install --no-deps -t bin %{SOURCE6}
+PYTHONPATH="$(pwd)/bin" \
+%{__python3} -m pip install --no-deps -t bin %{SOURCE6}
+PYTHONPATH="$(pwd)/bin" \
 %{__python3} -m pip install --no-deps -t bin %{SOURCE7}
+PYTHONPATH="$(pwd)/bin" \
 %{__python3} -m pip install --no-deps -t bin %{SOURCE8}
+PYTHONPATH="$(pwd)/bin" \
 %{__python3} -m pip install --no-deps -t bin %{SOURCE11}
 # RHEL specifically, not CentOS:
 %if 0%{?centos} == 0
-PYTHONPATH=bin/ %{__python3} -m pip install --no-deps -t bin %{SOURCE12}
-PYTHONPATH=bin/ %{__python3} -m pip install --no-deps -t bin %{SOURCE13}
+PYTHONPATH="$(pwd)/bin" \
+%{__python3} -m pip install --no-deps -t bin %{SOURCE12}
+PYTHONPATH="$(pwd)/bin" \
+%{__python3} -m pip install --no-deps -t bin %{SOURCE13}
+PYTHONPATH="$(pwd)/bin" \
 %{__python3} -m pip install --no-deps -t bin %{SOURCE14}
 %endif
+PYTHONPATH="$(pwd)/bin" \
 %{__python3} -m pip install --no-deps -t bin %{SOURCE15}
+PYTHONPATH="$(pwd)/bin" \
 %{__python3} -m pip install --no-deps -t bin %{SOURCE16}
+PYTHONPATH="$(pwd)/bin" \
 %{__python3} -m pip install --no-deps -t bin %{SOURCE17}
+PYTHONPATH="$(pwd)/bin" \
 %{__python3} -m pip install --no-deps -t bin %{SOURCE18}
+PYTHONPATH="$(pwd)/bin" \
 %{__python3} -m pip install --no-deps -t bin %{SOURCE19}
+PYTHONPATH="$(pwd)/bin" \
 %{__python3} -m pip install --no-deps -t bin %{SOURCE20}
+PYTHONPATH="$(pwd)/bin" \
 %{__python3} -m pip install --no-deps -t bin %{SOURCE21}
+PYTHONPATH="$(pwd)/bin" \
 %{__python3} -m pip install --no-deps -t bin %{SOURCE22}
+PYTHONPATH="$(pwd)/bin" \
 %{__python3} -m pip install --no-deps -t bin %{SOURCE23}
+PYTHONPATH="$(pwd)/bin" \
 %{__python3} -m pip install --no-deps -t bin %{SOURCE24}
 %endif
 
@@ -168,7 +192,7 @@ PYTHONPATH=bin/ %{__python3} -m pip install --no-deps -t bin %{SOURCE13}
 
 # RHEL or CentOS:
 %if 0%{?rhel}
-PYTHONPATH=bin/ \
+PYTHONPATH="$(pwd)/bin" \
 %{__python3} \
   -m build \
   --wheel \
@@ -209,7 +233,7 @@ export PYTHONPATH="%{buildroot_site_packages}:${PYTHONPATH}"
   --deselect tests/unit/scp_test.py::test_put
 # CentOS or RHEL:
 %else
-export PYTHONPATH="bin/:${PYTHONPATH}"
+export PYTHONPATH="$(pwd)/bin:${PYTHONPATH}"
 %{__python3} -m pytest \
   --no-cov \
   --deselect tests/unit/scp_test.py::test_get \


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Currently building RPMs fails on `pip install` because the
system-level libs are too old for some deps to get built.
Previously, I've attempted to use the relative `bin/` but at some
point it stopped working. `rpmbuild` must've changed their CWD.

This patch fixes this issue.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Packaging Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
N/A