### PR TITLE
Tell pre-commit.ci to send update PRs quarterly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,7 @@
 ---
+ci:
+  autoupdate_schedule: quarterly
+
 repos:
 - repo: https://github.com/asottile/add-trailing-comma.git
   rev: v2.2.3


### PR DESCRIPTION
##### SUMMARY

This is necessary so that it's not very disruptive when flake8 plugins can't keep up with compatibility updates.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
https://github.com/pre-commit-ci/issues/issues/140