### PR TITLE
Fix cutting off expandvars from RPM spec @ Fedora

### DIFF
--- a/docs/changelog-fragments/378.misc.rst
+++ b/docs/changelog-fragments/378.misc.rst
@@ -1,0 +1,6 @@
+Fixed removing ``expandvars`` from ``pyproject.toml``
+in an RPM spec -- by :user:`webknjaz`
+
+Before this patch, the ``sed`` invocation removed entire
+``build-system.requires`` entry from there, in rare cases
+but this won't be happening anymore.

--- a/packaging/rpm/ansible-pylibssh.spec
+++ b/packaging/rpm/ansible-pylibssh.spec
@@ -116,7 +116,7 @@ $summary
 
 # Fedora:
 %if 0%{?fedora}
-sed -i '/"expandvars",/d' pyproject.toml
+sed -i 's/\(.*\)"expandvars",\(.*\)/\1\2/g' pyproject.toml
 %endif
 
 PYTHONPATH="$(pwd)/bin" \


### PR DESCRIPTION
##### SUMMARY

Testing of the Fedora RPM spec is green in PRs but keeps failing on the default branch. This is the result of a combination of a few factors.

The `pyproject.toml` file is being modified in "nightly" CI runs, adding `local_scheme = "no-local-version"` there but not using a style-preserving TOML writer. And so it rewrote the `requires` entry in one line. Also, this is happening in a job that is separate from building RPMs.

Unrelated to that, the RPM spec removes the line with `expandvars` in it, which was fine when it was on a separate line but now that it gets reformatted, the whole list of `requires` just gets wiped under specific hard-to-track-down circumstances.

This patch corrects the `sed` invocation to be more granular but ultimately, a better approach would be to change the GHA workflow to make a local Git tag while building dists instead of modifying `pyproject.toml`. This will be done separately.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Packaging Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
N/A