### PR TITLE
Replace deprecated Ubuntu 18.04 VM with 20.04 @ GHA

### DIFF
--- a/.github/workflows/build-test-n-publish.yml
+++ b/.github/workflows/build-test-n-publish.yml
@@ -855,10 +855,15 @@ jobs:
       if: >-
         runner.os == 'macOS'
       run: brew install libssh
-    - name: Install libssh headers on Linux for cythonize+coverage
+    - name: Install catchsegv and libssh headers on Linux for cythonize+coverage
       if: >-
         runner.os == 'Linux'
-      run: sudo apt update && sudo apt install libssh-dev
+      run: >-
+        sudo apt update && sudo apt install ${{
+          matrix.runner-vm-os != 'ubuntu-20.04'
+          && 'glibc-tools'
+          || ''
+        }} libssh-dev
     - name: Switch 🐍 to v${{ matrix.python-version }}
       uses: actions/setup-python@v4.2.0
       with:

--- a/.github/workflows/build-test-n-publish.yml
+++ b/.github/workflows/build-test-n-publish.yml
@@ -834,6 +834,9 @@ jobs:
         dist-type:
         - binary
         - source
+        exclude:
+        - runner-vm-os: ubuntu-22.04
+          python-version: 3.6  # EOL, only provided for older OSs
 
     env:
       ANSIBLE_PYLIBSSH_TRACING: >-

--- a/.github/workflows/build-test-n-publish.yml
+++ b/.github/workflows/build-test-n-publish.yml
@@ -828,9 +828,9 @@ jobs:
         - 3.7
         - 3.6
         runner-vm-os:
-        - ubuntu-20.04
+        - ubuntu-22.04
         - macos-latest
-        - ubuntu-18.04
+        - ubuntu-20.04
         dist-type:
         - binary
         - source
@@ -843,11 +843,11 @@ jobs:
       TOX_PARALLEL_NO_SPINNER: 1
 
     steps:
-    - name: Install libssh and openssl headers on Linux
+    - name: Install build toolchain and openssl headers on Linux
       if: >-
         matrix.dist-type == 'source' &&
         runner.os == 'Linux'
-      run: sudo apt update && sudo apt install libssh-dev libssl-dev build-essential
+      run: sudo apt update && sudo apt install build-essential libssl-dev
     - name: Install libssh and openssl headers on macOS
       if: >-
         runner.os == 'macOS'
@@ -855,7 +855,7 @@ jobs:
     - name: Install libssh headers on Linux for cythonize+coverage
       if: >-
         runner.os == 'Linux'
-      run: sudo add-apt-repository ppa:kedazo/libssh-0.7.x && sudo apt update && sudo apt install libssh-dev
+      run: sudo apt update && sudo apt install libssh-dev
     - name: Switch 🐍 to v${{ matrix.python-version }}
       uses: actions/setup-python@v4.2.0
       with:

--- a/docs/changelog-fragments/379.deprecation.rst
+++ b/docs/changelog-fragments/379.deprecation.rst
@@ -1,0 +1,2 @@
+The project stopped being tested under Ubuntu 18.04 VM since
+GitHub is sunetting their CI images -- by :user:`webknjaz`


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
$sbj.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request
- Testing Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
There are planned brownouts through March when our CI would fail in "unlucky" time slots. The final removal is planned for the April's Fool Day of 2023.

Ref: https://github.com/actions/runner-images/issues/6002