### PR TITLE
Replace RPM `%{expr}` with GHA expressions syntax

### DIFF
--- a/.github/workflows/build-test-n-publish.yml
+++ b/.github/workflows/build-test-n-publish.yml
@@ -704,6 +704,23 @@ jobs:
         dist/ansible-pylibssh-${{ needs.pre-setup.outputs.dist_version }}.tar.gz
         ~/rpmbuild/SOURCES/
 
+    - name: Install static test dependencies missing from UBI9
+      if: contains(matrix.target-container.tag, 'ubi9')
+      run: >-
+        rpm
+        -ivh
+        --nodeps
+        https://rpmfind.net/linux/centos-stream/"$(
+          rpm --eval '%{rhel}'
+        )"-stream/CRB/x86_64/os/Packages/python3-pytest-6.2.2-6${{
+          steps.distribution-meta.outputs.dist-tag
+        }}.noarch.rpm
+        https://rpmfind.net/linux/centos-stream/"$(
+          rpm --eval '%{rhel}'
+        )"-stream/CRB/x86_64/os/Packages/python3-wheel-0.36.2-7${{
+          steps.distribution-meta.outputs.dist-tag
+        }}.noarch.rpm
+
     - name: Install static test dependencies missing from UBI8
       if: contains(matrix.target-container.tag, 'ubi8')
       run: >-
@@ -719,13 +736,85 @@ jobs:
         rpm
         -ivh
         --nodeps
-        https://rpmfind.net/linux/epel/"$(rpm --eval '%{rhel}')"/Everything/x86_64/Packages/p/python3-pytest-cov-$(rpm --eval '%{expr:%rhel==9?"3.0.0-8":"2.6.0-1"}')${{ steps.distribution-meta.outputs.dist-tag }}.noarch.rpm
-        https://rpmfind.net/linux/epel/"$(rpm --eval '%{rhel}')"/Everything/x86_64/Packages/p/python3-pytest-forked-$(rpm --eval '%{expr:%rhel==9?"1.4.0":"1.0.2"}')-1${{ steps.distribution-meta.outputs.dist-tag }}.noarch.rpm
-        https://rpmfind.net/linux/epel/"$(rpm --eval '%{rhel}')"/Everything/x86_64/Packages/p/python3-pytest-xdist-$(rpm --eval '%{expr:%rhel==9?"2.5.0-2":"1.24.1-1"}')${{ steps.distribution-meta.outputs.dist-tag }}.noarch.rpm
-        https://rpmfind.net/linux/epel/"$(rpm --eval '%{rhel}')"/Everything/x86_64/Packages/$(rpm --eval '%{expr:%rhel==9?"t":"p"}')/$(rpm --eval '%{expr:%rhel!=9?"python3-":""}')tox-$(rpm --eval '%{expr:%rhel==9?"3.25.0-1":"3.4.0-2"}')${{ steps.distribution-meta.outputs.dist-tag }}.noarch.rpm
-        https://rpmfind.net/linux/epel/"$(rpm --eval '%{rhel}')"/Everything/x86_64/Packages/p/python3-execnet-$(rpm --eval '%{expr:%rhel==9?"1.9.0-3":"1.7.1-1"}')${{ steps.distribution-meta.outputs.dist-tag }}.noarch.rpm
-        https://rpmfind.net/linux/$(rpm --eval '%{expr:%rhel==9?"epel":"centos"}')/"$(rpm --eval '%{rhel}')"$(rpm --eval '%{expr:%rhel!=9?"-stream"}')/$(rpm --eval '%{expr:%rhel==9?"Everything":"AppStream"}')/x86_64/$(rpm --eval '%{expr:%rhel!=9?"os/"}')Packages/python3-coverage-$(rpm --eval '%{expr:%rhel==9?"6.2-1":"4.5.1-9"}')${{ steps.distribution-meta.outputs.dist-tag }}.x86_64.rpm
-        https://rpmfind.net/linux/epel/"$(rpm --eval '%{rhel}')"/Everything/x86_64/Packages/p/python3-apipkg-$(rpm --eval '%{expr:%rhel==9?"2.1.1-1":"1.5-6"}')${{ steps.distribution-meta.outputs.dist-tag }}.noarch.rpm
+        https://rpmfind.net/linux/epel/"$(
+          rpm --eval '%{rhel}'
+        )"/Everything/x86_64/Packages/p/python3-pytest-cov-${{
+          contains(matrix.target-container.tag, 'ubi9')
+          && '3.0.0-8'
+          || '2.6.0-1'
+        }}${{ steps.distribution-meta.outputs.dist-tag }}.noarch.rpm
+        https://rpmfind.net/linux/epel/"$(
+          rpm --eval '%{rhel}'
+        )"/Everything/x86_64/Packages/p/python3-pytest-forked-${{
+          contains(matrix.target-container.tag, 'ubi9')
+          && '1.4.0'
+          || '1.0.2'
+        }}-1${{
+          steps.distribution-meta.outputs.dist-tag
+        }}.noarch.rpm
+        https://rpmfind.net/linux/epel/"$(
+          rpm --eval '%{rhel}'
+        )"/Everything/x86_64/Packages/p/python3-pytest-xdist-${{
+          contains(matrix.target-container.tag, 'ubi9')
+          && '2.5.0-2'
+          || '1.24.1-1'
+        }}${{ steps.distribution-meta.outputs.dist-tag }}.noarch.rpm
+        https://rpmfind.net/linux/epel/"$(
+          rpm --eval '%{rhel}'
+        )"/Everything/x86_64/Packages/${{
+          contains(matrix.target-container.tag, 'ubi9')
+          && 't'
+          || 'p'
+        }}/${{
+          !contains(matrix.target-container.tag, 'ubi9')
+          && 'python3-'
+          || ''
+        }}tox-${{
+          contains(matrix.target-container.tag, 'ubi9')
+          && '3.25.0-1'
+          || '3.4.0-2'
+        }}${{ steps.distribution-meta.outputs.dist-tag }}.noarch.rpm
+        https://rpmfind.net/linux/epel/"$(
+          rpm --eval '%{rhel}'
+        )"/Everything/x86_64/Packages/p/python3-execnet-${{
+          contains(matrix.target-container.tag, 'ubi9')
+          && '1.9.0-3'
+          || '1.7.1-1'
+        }}${{ steps.distribution-meta.outputs.dist-tag }}.noarch.rpm
+        https://rpmfind.net/linux/${{
+          contains(matrix.target-container.tag, 'ubi9')
+          && 'epel'
+          || 'centos'
+        }}/"$(
+          rpm --eval '%{rhel}'
+        )"${{
+          !contains(matrix.target-container.tag, 'ubi9')
+          && '-stream'
+          || ''
+        }}/${{
+          contains(matrix.target-container.tag, 'ubi9')
+          && 'Everything'
+          || 'AppStream'
+        }}/x86_64/${{
+          !contains(matrix.target-container.tag, 'ubi9')
+          && 'os/'
+          || ''
+        }}Packages/${{
+          contains(matrix.target-container.tag, 'ubi9')
+          && 'p/'
+          || ''
+        }}python3-coverage-${{
+          contains(matrix.target-container.tag, 'ubi9')
+          && '6.2-1'
+          || '4.5.1-9'
+        }}${{ steps.distribution-meta.outputs.dist-tag }}.x86_64.rpm
+        https://rpmfind.net/linux/epel/"$(
+          rpm --eval '%{rhel}'
+        )"/Everything/x86_64/Packages/p/python3-apipkg-${{
+          contains(matrix.target-container.tag, 'ubi9')
+          && '2.1.1-1'
+          || '1.5-6'
+        }}${{ steps.distribution-meta.outputs.dist-tag }}.noarch.rpm
 
     - name: Install static build requirements
       run: dnf builddep --assumeyes --spec packaging/rpm/ansible-pylibssh.spec

--- a/.github/workflows/build-test-n-publish.yml
+++ b/.github/workflows/build-test-n-publish.yml
@@ -997,6 +997,7 @@ jobs:
     if: always()
 
     needs:
+    - build-rpms
     - dist-meta
     - test-matrix
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
$sbj. It's a follow-up for #380.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Maintenance Pull Request
- Testing Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This is needed because the ternary macro syntax first appeared in
RPM v4.16 [1] but UBI 8 only has v4.14.3 and it's non-upgradable.

[1]: https://rpm.org/wiki/Releases/4.16.0
