### PR TITLE
Fix temporary workaround for pytest-cov w/ xdist

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -51,6 +51,10 @@ filterwarnings =
   ignore:Coverage disabled via --no-cov switch!:pytest.PytestWarning:pytest_cov.plugin
   ignore:pytest-forked xfail support is incomplete at the moment and may output a misleading reason message:RuntimeWarning:pytest_forked
 
+  # FIXME: drop this once `pytest-cov` is updated.
+  # Ref: https://github.com/pytest-dev/pytest-cov/issues/557
+  ignore:The --rsyncdir command line argument and rsyncdirs config variable are deprecated.:DeprecationWarning
+
 junit_duration_report = call
 junit_family = xunit2
 junit_logging = all

--- a/tox.ini
+++ b/tox.ini
@@ -19,8 +19,7 @@ deps =
   pytest
   pytest-cov
   pytest-forked
-  # Temporary workaround for https://github.com/pytest-dev/pytest-cov/issues/557
-  pytest-xdist < 3.0.2
+  pytest-xdist
 passenv =
   PYTHONPATH
 commands_pre =
@@ -45,7 +44,7 @@ deps =
   pytest
   pytest-cov
   pytest-forked
-  pytest-xdist < 3.0.2
+  pytest-xdist
 setenv =
   ANSIBLE_PYLIBSSH_TRACING = {env:ANSIBLE_PYLIBSSH_TRACING:1}
   CATCHSEGV_BINARY = {env:CATCHSEGV_BINARY:}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The patch introduced in https://github.com/ansible/pylibssh/pull/397 restricts the package versions but the right thing to do is to tell pytest not to turn this specific warning into an error and just ignore it for now.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
N/A
