### PR TITLE
Implement retries in SSH connection pytest fixture

### DIFF
--- a/docs/changelog-fragments/405.misc.rst
+++ b/docs/changelog-fragments/405.misc.rst
@@ -1,0 +1,1 @@
+Added an SSH connection re-try helper to tests -- by :user:`webknjaz`

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,13 +3,14 @@
 
 """Pytest plugins and fixtures configuration."""
 
-import getpass
 import shutil
 import socket
 import subprocess
 
 import pytest
-from _service_utils import wait_for_svc_ready_state  # noqa: WPS300, WPS436
+from _service_utils import (  # noqa: WPS436
+    ensure_ssh_session_connected, wait_for_svc_ready_state,
+)
 
 from pylibsshext.session import Session
 
@@ -112,16 +113,8 @@ def ssh_client_session(sshd_addr, ssh_clientkey_path):
 
     # noqa: DAR101
     """
-    hostname, port = sshd_addr
     ssh_session = Session()
-    ssh_session.connect(
-        host=hostname,
-        port=port,
-        user=getpass.getuser(),
-        private_key=ssh_clientkey_path.read_bytes(),
-        host_key_checking=False,
-        look_for_keys=False,
-    )
+    ensure_ssh_session_connected(ssh_session, sshd_addr, ssh_clientkey_path)
     try:  # noqa: WPS501
         yield ssh_session
     finally:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This patch is supposed to make the tests more stable and prevent crashes caused by this.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request
- Testing Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

```python-traceback
__________________________ ERROR at setup of test_put __________________________
[gw1] linux -- Python 3.8.14 /home/runner/work/pylibssh/pylibssh/.tox/test-binary-dists/bin/python

sshd_addr = ('127.0.0.1', 33317)
ssh_clientkey_path = PosixPath('/tmp/pytest-of-runner/pytest-0/popen-gw1/test_put0/sshd/ssh_client_rsa_key')

    @pytest.fixture
    def ssh_client_session(sshd_addr, ssh_clientkey_path):
        """Authenticate against SSHD with a private SSH key.

        :yields: Pre-authenticated SSH session.
        :ytype: pylibsshext.session.Session

        # noqa: DAR101
        """
        hostname, port = sshd_addr
        ssh_session = Session()
>       ssh_session.connect(
            host=hostname,
            port=port,
            user=getpass.getuser(),
            private_key=ssh_clientkey_path.read_bytes(),
            host_key_checking=False,
            look_for_keys=False,
        )

hostname   = '127.0.0.1'
port       = 33317
ssh_clientkey_path = PosixPath('/tmp/pytest-of-runner/pytest-0/popen-gw1/test_put0/sshd/ssh_client_rsa_key')
ssh_session = <pylibsshext.session.Session object at 0x7f7229b8e090>
sshd_addr  = ('127.0.0.1', 33317)

tests/conftest.py:117:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

>   raise LibsshSessionException("ssh connect failed: %s" % self._get_session_error_str())
E   pylibsshext.errors.LibsshSessionException: ssh connect failed: Socket error: Connection reset by peer
```

Ref: https://github.com/ansible/pylibssh/actions/runs/3401263608/jobs/5656345704#step:13:272