### PR TITLE
Start publishing dumb-pypi w/ actions/deploy-pages

### DIFF
--- a/.github/workflows/build-test-n-publish.yml
+++ b/.github/workflows/build-test-n-publish.yml
@@ -1230,6 +1230,18 @@ jobs:
       fromJSON(needs.pre-setup.outputs.is-tagged)
     runs-on: ubuntu-latest
 
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}/simple/ansible-pylibssh/
+
+    permissions:
+      contents: read  # This job doesn't need to `git push` anything
+      pages: write  # This allows to publish a GitHub Pages site
+      # `id-token` allows GitHub Pages to verify the deployment originates
+      # from an appropriate source through OpenID Connect, according to the
+      # README of the `actions/deploy-pages` action.
+      id-token: write
+
     steps:
     - name: Download the recent published versions from TestPyPI
       run: >-
@@ -1298,12 +1310,14 @@ jobs:
         to the generated dumb PyPI website dir
       run: cp -av dist gh-pages-dumb-pypi/
 
-    - name: Publish the dumb PyPI website to GH Pages
-      uses: peaceiris/actions-gh-pages@v3.9.0
+    - name: Upload GitHub Pages artifact
+      uses: actions/upload-pages-artifact@v1
       with:
-        force_orphan: true
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: gh-pages-dumb-pypi
+        path: gh-pages-dumb-pypi
+
+    - name: Publish the dumb PyPI website to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v1
 
 ...
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This changes the custom-action-based GitHub pages publishing mechanism with the new official one.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
- https://github.blog/changelog/2022-07-27-github-pages-custom-github-actions-workflows-beta/
- https://github.blog/2022-08-10-github-pages-now-uses-actions-by-default/
- https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#creating-a-custom-github-actions-workflow-to-publish-your-site
