### PR TITLE
🐛 Fix copying src dir to tmp in manylinux script

### DIFF
--- a/build-scripts/build-manylinux-wheels.sh
+++ b/build-scripts/build-manylinux-wheels.sh
@@ -116,7 +116,8 @@ for PY in $PYTHONS; do
         cp -v "${PEP517_CONFIG_FILE}" "${ISOLATED_SRC_DIRS}/${PY}"/
     else
         # NOTE: Rely on `.git_archival.txt` for versioning
-        cp -v "${SRC_DIR}" "${ISOLATED_SRC_DIRS}/${PY}"
+        mkdir -pv "${ISOLATED_SRC_DIRS}/"
+        cp -a "${SRC_DIR}" "${ISOLATED_SRC_DIRS}/${PY}"
     fi
 done
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
$sbj.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Packaging Pull Request
- Testing Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The thing copied is a dir so `cp` explodes without this flag.

This bug was introduced in https://github.com/ansible/pylibssh/pull/413/files#diff-b577f35d4f0228673b8c7fb9835357f7cbdf6435942ab40f2ada1b3508358350R119.
