### PR TITLE
Fix release versioning for pushes to `devel`

### DIFF
--- a/.github/workflows/build-test-n-publish.yml
+++ b/.github/workflows/build-test-n-publish.yml
@@ -478,6 +478,15 @@ jobs:
         xargs git tag --delete
       shell: bash
 
+    - name: >-
+        Tag the current checkout HEAD in the local Git repo
+        as ${{ needs.pre-setup.outputs.git-tag }}
+      if: >-
+        fromJSON(needs.pre-setup.outputs.is-untagged-devel)
+      run: >-
+        git tag
+        -m '${{ needs.pre-setup.outputs.git-tag }}'
+        '${{ needs.pre-setup.outputs.git-tag }}'
     - name: Write the current version metadata to `.git_archival.txt`
       if: >-
         fromJSON(needs.pre-setup.outputs.is-untagged-devel)
@@ -754,6 +763,15 @@ jobs:
         xargs git tag --delete
       shell: bash
 
+    - name: >-
+        Tag the current checkout HEAD in the local Git repo
+        as ${{ needs.pre-setup.outputs.git-tag }}
+      if: >-
+        fromJSON(needs.pre-setup.outputs.is-untagged-devel)
+      run: >-
+        git tag
+        -m '${{ needs.pre-setup.outputs.git-tag }}'
+        '${{ needs.pre-setup.outputs.git-tag }}'
     - name: Write the current version metadata to `.git_archival.txt`
       if: >-
         fromJSON(needs.pre-setup.outputs.is-untagged-devel)
@@ -930,6 +948,15 @@ jobs:
         xargs git tag --delete
       shell: bash
 
+    - name: >-
+        Tag the current checkout HEAD in the local Git repo
+        as ${{ needs.pre-setup.outputs.git-tag }}
+      if: >-
+        fromJSON(needs.pre-setup.outputs.is-untagged-devel)
+      run: >-
+        git tag
+        -m '${{ needs.pre-setup.outputs.git-tag }}'
+        '${{ needs.pre-setup.outputs.git-tag }}'
     - name: Write the current version metadata to `.git_archival.txt`
       if: >-
         fromJSON(needs.pre-setup.outputs.is-untagged-devel)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This patch tags the Git commit before generating the `.git_archival.txt` so that setuptools-scm has enough metadata to reconstruct the version from it, when the bare Git repository is removed.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Testing Pull Request
- Maintenance Pull Request