### PR TITLE
Separate AMD64 from other arches in CI build jobs

### DIFF
--- a/.github/workflows/build-test-n-publish.yml
+++ b/.github/workflows/build-test-n-publish.yml
@@ -587,7 +587,7 @@ jobs:
               ) && 90 || 4
           }}
 
-  build-bin-manylinux:
+  build-bin-manylinux-tested-arches:
     name: >-
       👷 manylinux${{ matrix.manylinux-year-target
       }}-${{ matrix.manylinux-image-target.arch
@@ -627,10 +627,6 @@ jobs:
         manylinux-image-target:
         # NOTE: Keep in sync with `build-manylinux-container-images.yml`.
         # NOTE: Ordered from "heavy" to "fast".
-        - arch: aarch64
-          qemu_arch: arm64
-        - arch: s390x
-        - arch: ppc64le
         - arch: x86_64
           qemu_arch: amd64
         include:
@@ -681,6 +677,236 @@ jobs:
             arch: x86_64
             qemu_arch: amd64
           manylinux-year-target: 1
+
+    env:
+      ANSIBLE_PYLIBSSH_TRACING: >-
+        ${{ fromJSON(needs.pre-setup.outputs.profiling-enabled) && 1 || 0 }}
+      DOCKER_EXECUTABLE: podman
+      QEMU_ARCH: >-
+        ${{
+          matrix.manylinux-image-target.qemu_arch
+          || matrix.manylinux-image-target.arch
+        }}
+      TOXENV: >-
+        build-dists-manylinux${{ matrix.manylinux-year-target
+        }}-${{ matrix.manylinux-image-target.arch }},metadata-validation
+      TOX_PARALLEL_NO_SPINNER: 1
+
+    steps:
+    - name: Switch to using Python 3.11 by default
+      uses: actions/setup-python@v4.3.0
+      with:
+        python-version: 3.11
+
+    - name: Grab the source from Git
+      uses: actions/checkout@v3.1.0
+      with:
+        fetch-depth: >-
+          ${{
+              fromJSON(needs.pre-setup.outputs.release-requested)
+              && 1 || 0
+          }}
+        ref: ${{ github.event.inputs.release-commitish }}
+
+    - name: >-
+        Calculate Python interpreter version hash value
+        for use in the cache key
+      id: calc-cache-key-py
+      run: |
+        from hashlib import sha512
+        from os import environ
+        from pathlib import Path
+        from sys import version
+
+        FILE_APPEND_MODE = 'a'
+
+        hash = sha512(version.encode()).hexdigest()
+
+        with Path(environ['GITHUB_OUTPUT']).open(
+                mode=FILE_APPEND_MODE,
+        ) as outputs_file:
+            print(f'py-hash-key={hash}', file=outputs_file)
+      shell: python
+    - name: Set up pip cache
+      uses: actions/cache@v3.0.11
+      with:
+        path: >-
+          ${{
+              runner.os == 'Linux'
+              && '~/.cache/pip'
+              || '~/Library/Caches/pip'
+          }}
+        key: >-
+          ${{ runner.os }}-pip-${{
+          steps.calc-cache-key-py.outputs.py-hash-key }}-${{
+          needs.pre-setup.outputs.cache-key-files }}
+        restore-keys: |
+          ${{ runner.os }}-pip-${{
+            steps.calc-cache-key-py.outputs.py-hash-key
+          }}-
+          ${{ runner.os }}-pip-
+          ${{ runner.os }}-
+    - name: Install tox
+      run: >-
+        python -m
+        pip install
+        --user
+        tox
+
+    - name: Pre-populate the tox env
+      run: >-
+        python -m
+        tox
+        --parallel auto
+        --parallel-live
+        --skip-missing-interpreters false
+        --notest
+
+    - name: Drop Git tags from HEAD for non-tag-create events
+      if: >-
+        !fromJSON(needs.pre-setup.outputs.release-requested)
+      run: >-
+        git tag --points-at HEAD
+        |
+        xargs git tag --delete
+      shell: bash
+
+    - name: Setup git user as [bot]
+      if: >-
+        fromJSON(needs.pre-setup.outputs.release-requested)
+        || fromJSON(needs.pre-setup.outputs.is-untagged-devel)
+      uses: fregante/setup-git-user@v1.1.0
+    - name: >-
+        Tag the release in the local Git repo
+        as ${{ needs.pre-setup.outputs.git-tag }}
+        for setuptools-scm to set the desired version
+      if: >-
+        fromJSON(needs.pre-setup.outputs.release-requested)
+      run: >-
+        git tag
+        -m '${{ needs.pre-setup.outputs.git-tag }}'
+        '${{ needs.pre-setup.outputs.git-tag }}'
+        --
+        ${{
+          fromJSON(needs.pre-setup.outputs.release-requested)
+          && github.event.inputs.release-commitish || ''
+        }}
+
+    - name: Install tomlkit Python distribution package
+      if: >-
+        fromJSON(needs.pre-setup.outputs.is-untagged-devel)
+      run: >-
+        python -m pip install --user tomlkit
+    - name: Instruct setuptools-scm not to add a local version part
+      if: >-
+        fromJSON(needs.pre-setup.outputs.is-untagged-devel)
+      run: |
+        from pathlib import Path
+
+        import tomlkit
+
+        pyproject_toml_path = Path.cwd() / 'pyproject.toml'
+        pyproject_toml_txt = pyproject_toml_path.read_text()
+        pyproject_toml = tomlkit.loads(pyproject_toml_txt)
+        setuptools_scm_section = pyproject_toml['tool']['setuptools_scm']
+        setuptools_scm_section['local_scheme'] = 'no-local-version'
+        patched_pyproject_toml_txt = tomlkit.dumps(pyproject_toml)
+        pyproject_toml_path.write_text(patched_pyproject_toml_txt)
+      shell: python
+    - name: Pretend that pyproject.toml is unchanged
+      if: >-
+        fromJSON(needs.pre-setup.outputs.is-untagged-devel)
+      run: |
+        git diff --color=always
+        git update-index --assume-unchanged pyproject.toml
+
+    - name: >-
+        Set up QEMU ${{ env.QEMU_ARCH }} arch emulation
+        with Podman
+      if: env.QEMU_ARCH != 'amd64'
+      run: >-
+        sudo podman run
+        --rm --privileged
+        multiarch/qemu-user-static
+        --reset -p yes
+
+    - name: >-
+        Build ${{ matrix.manylinux-python-target }} dist
+        and verify wheel metadata
+      run: >-
+        python -m
+        tox
+        --parallel auto
+        --parallel-live
+        --skip-missing-interpreters false
+        --skip-pkg-install
+        --
+        ${{ matrix.manylinux-python-target }}
+    - name: Verify that the artifacts with expected names got created
+      run: >-
+        ls -1
+        dist/${{ needs.pre-setup.outputs.wheel-artifact-name }}
+    - name: Store ${{ matrix.manylinux-python-target }} binary wheel
+      uses: actions/upload-artifact@v3
+      with:
+        name: python-package-distributions
+        # NOTE: Exact expected file names are specified here
+        # NOTE: as a safety measure — if anything weird ends
+        # NOTE: up being in this dir or not all dists will be
+        # NOTE: produced, this will fail the workflow.
+        path: |
+          dist/${{ needs.pre-setup.outputs.wheel-artifact-name }}
+        retention-days: >-
+          ${{
+              (
+                fromJSON(needs.pre-setup.outputs.release-requested)
+              ) && 90 || 4
+          }}
+
+  build-bin-manylinux-odd-arches:
+    name: >-
+      👷 manylinux${{ matrix.manylinux-year-target
+      }}-${{ matrix.manylinux-image-target.arch
+      }} 📦 ${{ needs.pre-setup.outputs.git-tag }}
+      for 🐍 ${{ matrix.manylinux-python-target }}
+      [mode: ${{
+        fromJSON(needs.pre-setup.outputs.is-untagged-devel)
+        && 'nightly' || ''
+      }}${{
+        fromJSON(needs.pre-setup.outputs.release-requested)
+        && 'release' || ''
+      }}${{
+        (
+          !fromJSON(needs.pre-setup.outputs.is-untagged-devel)
+          && !fromJSON(needs.pre-setup.outputs.release-requested)
+        ) && 'test' || ''
+      }}]
+    needs:
+    - pre-setup
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        manylinux-python-target:
+        # NOTE: Must be from this list:
+        # NOTE: $ podman run -it --rm \
+        # NOTE:   quay.io/pypa/manylinux2014_x86_64 \
+        # NOTE:   ls -1 /opt/python
+        - cp36-cp36m
+        - cp37-cp37m
+        - cp38-cp38
+        - cp39-cp39
+        - cp310-cp310
+        - cp311-cp311
+        manylinux-year-target:
+        - 2014
+        - _2_24
+        manylinux-image-target:
+        # NOTE: Keep in sync with `build-manylinux-container-images.yml`.
+        # NOTE: Ordered from "heavy" to "fast".
+        - arch: aarch64
+          qemu_arch: arm64
+        - arch: s390x
+        - arch: ppc64le
 
     env:
       ANSIBLE_PYLIBSSH_TRACING: >-
@@ -1372,7 +1598,7 @@ jobs:
       ${{ matrix.dist-type }} dists
     needs:
     - build-bin-macos
-    - build-bin-manylinux
+    - build-bin-manylinux-tested-arches
     - build-src
     - pre-setup  # transitive, for accessing settings
     runs-on: ${{ matrix.runner-vm-os }}
@@ -1594,7 +1820,8 @@ jobs:
     name: Verify 🐍📦 metadata
     needs:
     - build-bin-macos
-    - build-bin-manylinux
+    - build-bin-manylinux-odd-arches
+    - build-bin-manylinux-tested-arches
     - build-src
     - pre-setup  # transitive, for accessing settings
     runs-on: ubuntu-latest


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This patch is aiming to make the tests more responsive by making the non-AMD64 build stage stop blocking the testing under AMD64 envs.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request
- Testing Pull Request