### PR TITLE
Unify PyPI token secret name as `PYPI_API_TOKEN`

### DIFF
--- a/.github/workflows/build-test-n-publish.yml
+++ b/.github/workflows/build-test-n-publish.yml
@@ -1710,7 +1710,7 @@ jobs:
         Publish 🐍📦 ${{ needs.pre-setup.outputs.git-tag }} to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        password: ${{ secrets.PYPI_TOKEN }}
+        password: ${{ secrets.PYPI_API_TOKEN }}
 
   publish-testpypi:
     name: Publish 🐍📦 ${{ needs.pre-setup.outputs.git-tag }} to TestPyPI


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This patch makes sure the PyPI API token in the “production” PyPI job is taken from an environment secret rather than from a global one.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request