### PR TITLE
Fix the wheel building container definitions

### DIFF
--- a/build-scripts/manylinux-container-image/install-userspace-tools.sh
+++ b/build-scripts/manylinux-container-image/install-userspace-tools.sh
@@ -14,7 +14,7 @@ VIRTUALENV_PIP_BIN="${VIRTUALENV_PYTHON_BIN} -m pip"
 TOOLS_PKGS=auditwheel
 if [ "${ARCH}" == "x86_64" ]
 then
-    TOOLS_PKGS="${TOOLS_PKGS} cmake"
+    TOOLS_PKGS="${TOOLS_PKGS} cmake --only-binary=cmake"
 fi
 
 # Avoid creation of __pycache__/*.py[c|o]

--- a/build-scripts/manylinux-container-image/install_zlib.sh
+++ b/build-scripts/manylinux-container-image/install_zlib.sh
@@ -10,10 +10,10 @@ MY_DIR=$(dirname "${BASH_SOURCE[0]}")
 source $MY_DIR/build_utils.sh
 source get-static-deps-dir.sh
 
-ZLIB_SHA256="91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9"
-ZLIB_VERSION="1.2.12"
+ZLIB_SHA256="b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30"
+ZLIB_VERSION="1.2.13"
 
-fetch_source "zlib-${ZLIB_VERSION}.tar.gz" "https://www.zlib.net"
+fetch_source "zlib-${ZLIB_VERSION}.tar.gz" "https://github.com/madler/zlib/releases/download/v${ZLIB_VERSION}"
 check_sha256sum "zlib-${ZLIB_VERSION}.tar.gz" ${ZLIB_SHA256}
 tar zxf "zlib-${ZLIB_VERSION}.tar.gz"
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
$sbj.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Maintenance Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Currently, the wheel container image rebuilding jobs are failing. We need them to succeed in order to make release-ready manylinux images with the final version of Python 3.11. The previously built images work, but they only have Python 3.11rc2 which may be slightly different from the final release.