### PR TITLE
Build manylinux wheels with libssh v0.9.6

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -263,7 +263,7 @@ commands =
     -i --rm \
     -v {toxinidir}:/io \
     -e ANSIBLE_PYLIBSSH_TRACING \
-    ghcr.io/ansible/pylibssh-manylinux{env:MANYLINUX_VERSION_TAG}_{env:MANYLINUX_ARCH_TAG}:libssh-v{env:LIBSSH_VERSION:0.9.4} \
+    ghcr.io/ansible/pylibssh-manylinux{env:MANYLINUX_VERSION_TAG}_{env:MANYLINUX_ARCH_TAG}:libssh-v{env:LIBSSH_VERSION:0.9.6} \
     /io/build-scripts/build-manylinux-wheels.sh \
     "manylinux{env:MANYLINUX_VERSION_TAG}_{env:MANYLINUX_ARCH_TAG}" \
     {posargs:}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
$sbj.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Depends on: https://github.com/ansible/pylibssh/pull/439.
Note: must wait for the new manylinux images to be published post merging #439 (via https://github.com/ansible/pylibssh/actions/runs/3451835550).