### PR TITLE
Retain GHA artifacts for max 7 days

### DIFF
--- a/.github/workflows/build-test-n-publish.yml
+++ b/.github/workflows/build-test-n-publish.yml
@@ -584,7 +584,7 @@ jobs:
           ${{
               (
                 fromJSON(needs.pre-setup.outputs.release-requested)
-              ) && 90 || 4
+              ) && 7 || 4
           }}
 
   build-bin-manylinux-tested-arches:
@@ -860,7 +860,7 @@ jobs:
           ${{
               (
                 fromJSON(needs.pre-setup.outputs.release-requested)
-              ) && 90 || 4
+              ) && 7 || 4
           }}
 
   build-bin-manylinux-odd-arches:
@@ -1090,7 +1090,7 @@ jobs:
           ${{
               (
                 fromJSON(needs.pre-setup.outputs.release-requested)
-              ) && 90 || 4
+              ) && 7 || 4
           }}
 
   build-src:
@@ -1273,7 +1273,7 @@ jobs:
           ${{
               (
                 fromJSON(needs.pre-setup.outputs.release-requested)
-              ) && 90 || 4
+              ) && 7 || 4
           }}
 
   build-rpms:


### PR DESCRIPTION
This is necessary to suppress the warnings about the repository settings limiting it to 7 days.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
$sbj.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request
