### PR TITLE
Third party libraries are located under /usr/local in FreeBSD

### DIFF
--- a/docs/changelog-fragments/477.bugfix.rst
+++ b/docs/changelog-fragments/477.bugfix.rst
@@ -1,2 +1,2 @@
-Extended CFLAGS to include header locations typical to FreeBSD
+Extended ``CFLAGS`` to include header locations typical to FreeBSD
 (:file:`/usr/local/include`) -- by :user:`donnerhacke`

--- a/docs/changelog-fragments/477.bugfix.rst
+++ b/docs/changelog-fragments/477.bugfix.rst
@@ -1,2 +1,2 @@
-- Extended CFLAGS to include header locations typical to FreeBSD
-  (:file:/usr/local/include) -- by :user:`donnerhacke`
+Extended CFLAGS to include header locations typical to FreeBSD
+(:file:/usr/local/include) -- by :user:`donnerhacke`

--- a/docs/changelog-fragments/477.bugfix.rst
+++ b/docs/changelog-fragments/477.bugfix.rst
@@ -1,2 +1,2 @@
 Extended CFLAGS to include header locations typical to FreeBSD
-(:file:/usr/local/include) -- by :user:`donnerhacke`
+(:file:`/usr/local/include`) -- by :user:`donnerhacke`

--- a/docs/changelog-fragments/477.bugfix.rst
+++ b/docs/changelog-fragments/477.bugfix.rst
@@ -1,0 +1,2 @@
+- Extended CFLAGS to include header locations typical to FreeBSD
+  (:file:/usr/local/include) -- by :user:`donnerhacke`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ src = ["src/**/*.pyx"]
 #ANSIBLE_PYLIBSSH_TRACING = "1"
 #CFLAGS = "-DCYTHON_TRACE=1 ${CFLAGS}"
 LDFLAGS = "-lssh ${LDFLAGS}"
+CFLAGS="-I /usr/local/include ${CFLAGS}"
 
 [tool.local.cythonize.flags]
 # This section can contain the following booleans:


### PR DESCRIPTION
##### SUMMARY
The filesystem hierarchy at FreeBSD requires non-essential libraries to be installed in the `/usr/local` tree. Hence the compiler needs to search `/usr/local/include` for the required header file `libssh/libssh.h`.

The project does not compile without specifying this path.

Supersedes #472 (wrong branch) 

##### ISSUE TYPE
- Bugfix Pull Request

##### ADDITIONAL INFORMATION
Before
```
cc -pthread -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -O2 -pipe -fstack-protector-strong -fno-strict-aliasing -DCYTHON_TRACE=1 -DCYTHON_TRACE_NOGIL=1 -fPIC -I/tmp/build-env-w5pvtdrg/include -I/usr/local/include/python3.9 -c /tmp/build-via-sdist-6bpb1mwc/ansible-pylibssh-0.1.dev1358+g11b206a/src/pylibsshext/_libssh_version.c -o /tmp/build-via-sdist-6bpb1mwc/ansible-pylibssh-0.1.dev1358+g11b206a/src/tmpnmc2mh29/tmp/build-via-sdist-6bpb1mwc/ansible-pylibssh-0.1.dev1358+g11b206a/src/pylibsshext/_libssh_version.o
/tmp/build-via-sdist-6bpb1mwc/ansible-pylibssh-0.1.dev1358+g11b206a/src/pylibsshext/_libssh_version.c:757:10: fatal error: 
      'libssh/libssh.h' file not found
#include "libssh/libssh.h"
         ^~~~~~~~~~~~~~~~~
1 error generated.
error: command '/usr/bin/cc' failed with exit code 1
```

After
```
24 warnings generated.
cc -pthread -shared -L/usr/local/lib -fstack-protector-strong -lssh -I /usr/local/include -DCYTHON_TRACE=1 -DCYTHON_TRACE_NOGIL=1 /tmp/build-via-sdist-7zkzyplu/ansible-pylibssh-0.1.dev1359+g7e61df1/src/tmpp0lv82d8/tmp/build-via-sdist-7zkzyplu/ansible-pylibssh-0.1.dev1359+g7e61df1/src/pylibsshext/scp.o -L/usr/local/lib -lssh -o build/lib.freebsd-13.1-STABLE-amd64-3.9/pylibsshext/scp.cpython-39.so
```
