### PR TITLE
🎨 Migrate PEP 517 backend to `tomllib`+`tomli`

### DIFF
--- a/docs/changelog-fragments/501.packaging.rst
+++ b/docs/changelog-fragments/501.packaging.rst
@@ -1,0 +1,6 @@
+The ``toml`` build time dependency has been replaced with
+``tomli`` -- by :user:`webknjaz`
+
+The ``tomli`` distribution is only pulled in under Python
+versions below 3.11. On 3.11 and higher, the standard
+library module :py:mod:`tomllib` is now used instead.

--- a/packaging/pep517_backend/_backend.py
+++ b/packaging/pep517_backend/_backend.py
@@ -8,7 +8,6 @@ import sys
 from functools import wraps
 from pathlib import Path
 
-import toml
 from expandvars import expandvars
 from setuptools.build_meta import (  # noqa: F401  # Re-exporting PEP 517 hooks
     build_sdist, build_wheel, get_requires_for_build_sdist,
@@ -22,10 +21,15 @@ from distutils.core import Distribution as DistutilsDistribution
 
 from Cython.Build.Cythonize import main as cythonize_cli_cmd
 
+from ._compat import load_toml_from_string  # noqa: WPS436
 from ._transformers import (  # noqa: WPS436
     convert_to_kwargs_only, get_cli_kwargs_from_config,
     get_enabled_cli_flags_from_config,
 )
+
+
+PROJECT_ROOT_DIR = Path(__file__).parents[2].resolve()
+PYPROJECT_TOML_PATH = PROJECT_ROOT_DIR / 'pyproject.toml'
 
 
 def get_config():
@@ -80,8 +84,8 @@ def get_config():
         # This section can contain cythonize options
         # NAME = "VALUE"
     """
-    config_file = (Path.cwd().resolve() / 'pyproject.toml').read_text()
-    config_toml = toml.loads(config_file)
+    config_file = PYPROJECT_TOML_PATH.read_text(encoding='utf-8')
+    config_toml = load_toml_from_string(config_file)
     return config_toml['tool']['local']['cythonize']
 
 

--- a/packaging/pep517_backend/_compat.py
+++ b/packaging/pep517_backend/_compat.py
@@ -1,0 +1,11 @@
+"""Cross-interpreter compatibility shims."""
+
+try:
+    # Python 3.11+
+    from tomllib import loads as load_toml_from_string  # noqa: WPS433
+except ImportError:
+    # before Python 3.11
+    from tomli import loads as load_toml_from_string  # noqa: WPS433, WPS440
+
+
+__all__ = ('load_toml_from_string',)  # noqa: WPS410

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
   # Essentials
   "Cython",  # needed by in-tree build backend `packaging/pep517_backend.py`
   "setuptools>=45",  # needed by in-tree build backend `packaging/pep517_backend.py`
-  "toml",  # needed by in-tree build backend `packaging/pep517_backend.py`
+  "tomli; python_version < '3.11'",  # needed by in-tree build backend `packaging/pep517_backend.py`
   "expandvars",  # needed by in-tree build backend for env vars interpolation
 
   # Plugins


### PR DESCRIPTION
`tomllib` is a part of stdlib since Python 3.11 and `tomli` is used as a fallback for the older Python versions. The latter is API-compatible with the former.

Fixes #504.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
$sbj.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request
- Packaging Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
N/A