### PR TITLE
🎨Only use setuptools-scm-git-archive under < py37

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1161,6 +1161,7 @@ jobs:
   build-src:
     name: >-
       👷 an sdist 📦 ${{ needs.pre-setup.outputs.git-tag }}
+      under ${{ matrix.python-version }}
       [mode: ${{
         fromJSON(needs.pre-setup.outputs.is-untagged-devel)
         && 'nightly' || ''
@@ -1176,7 +1177,23 @@ jobs:
     needs:
     - build-changelog
     - pre-setup  # transitive, for accessing settings
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner-vm-os }}
+    strategy:
+      matrix:
+        python-version:
+        - 3.8
+        - 3.7
+        runner-vm-os:
+        - ubuntu-22.04
+        store-sdist-to-artifact:
+        - false
+        include:
+        - python-version: 3.12
+          runner-vm-os: ubuntu-22.04
+          store-sdist-to-artifact: true
+        - python-version: 3.6  # EOL, only provided for older OSs
+          runner-vm-os: ubuntu-20.04
+          store-sdist-to-artifact: false
 
     env:
       ANSIBLE_PYLIBSSH_TRACING: >-
@@ -1185,10 +1202,10 @@ jobs:
       TOXENV: build-dists,metadata-validation
 
     steps:
-    - name: Switch to using Python 3.11
+    - name: Switch to using Python ${{ matrix.python-version }} 3.11
       uses: actions/setup-python@v5.0.0
       with:
-        python-version: 3.11
+        python-version: ${{ matrix.python-version }}
 
     - name: Grab the source from Git
       uses: actions/checkout@v4.1.1
@@ -1311,6 +1328,7 @@ jobs:
         ls -1
         'dist/${{ needs.pre-setup.outputs.sdist-artifact-name }}'
     - name: Store the source distribution package
+      if: fromJSON(matrix.store-sdist-to-artifact)
       uses: actions/upload-artifact@v3
       with:
         name: ${{ env.dists-artifact-name }}

--- a/docs/changelog-fragments/502.packaging.rst
+++ b/docs/changelog-fragments/502.packaging.rst
@@ -1,0 +1,2 @@
+Started using the built-in ``setuptools-scm`` Git archive
+support under Python 3.7 and higher -- :user:`webknjaz`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,12 @@ requires = [
   "expandvars",  # needed by in-tree build backend for env vars interpolation
 
   # Plugins
-  "setuptools_scm[toml]>=3.5",
-  "setuptools_scm_git_archive>=1.1",
+  "setuptools-scm >= 7.0.0; python_version >= '3.7'",
+  #  ^    supports git archives through a plugin
+  #  |                                        |
+  # supports git archives natively            V
+  "setuptools-scm[toml] >= 3.5, < 7.0.0; python_version < '3.7'",
+  "setuptools-scm-git-archive >= 1.1; python_version < '3.7'",
 ]
 backend-path = ["packaging"]  # requires 'Pip>=20' or 'pep517>=0.6.0'
 build-backend = "pep517_backend.hooks"

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -12,9 +12,11 @@ packaging==21.3
     # via setuptools-scm
 pyparsing==3.0.9
     # via packaging
-setuptools-scm==6.4.2
+setuptools-scm==6.4.2 ; python_version < "3.7"
+setuptools-scm==7.1.0 ; python_version == "3.7.*"
+setuptools-scm==8.0.4 ; python_version > "3.7"
     # via -r -
-setuptools-scm-git-archive==1.4
+setuptools-scm-git-archive==1.4 ; python_version < "3.7"
     # via -r -
 toml==0.10.2
     # via -r -


### PR DESCRIPTION
`setuptools-scm` supports Git archives natively starting v7 but it only supports Python 3.7 or higher. This patch makes up a set of conditional build dependencies that add `setuptools-scm-git-archive` only below Python 3.7 and in combination with an older version of `setuptools-scm`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Maintenance Pull Request
- Packaging Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
N/A