### PR TITLE
📦🐛 Fix PEP 660 editable install mode

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -61,7 +61,11 @@ per-file-ignores =
   docs/conf.py: WPS305
 
   # in-tree PEP517 build backend needs a lot of legit `noqa`s:
-  packaging/pep517_backend/_backend.py: WPS402
+  # ..and imports.
+  packaging/pep517_backend/_backend.py: WPS201, WPS402
+
+  # F401   imported but unused
+  packaging/pep517_backend/hooks.py: F401
 
   # The package has imports exposing private things to the public:
   src/pylibsshext/__init__.py: WPS412

--- a/docs/changelog-fragments/541.contrib.rst
+++ b/docs/changelog-fragments/541.contrib.rst
@@ -1,0 +1,4 @@
+:pep:`660` is now enabled -- :user:`webknjaz`
+
+This effectively means that the ecosystem-native editable
+install mode started working properly.

--- a/docs/changelog-fragments/541.packaging.rst
+++ b/docs/changelog-fragments/541.packaging.rst
@@ -1,0 +1,7 @@
+:pep:`660` is now enabled -- :user:`webknjaz`
+
+Previously, due to restrictive :pep:`517` hook reimports,
+our in-tree build backend was losing :pep:`non-PEP 517 <517>`
+hooks implemented in newer versions of ``setuptools`` but not
+the earlier ones. This is now addressed by reexporting
+everything that ``setuptools`` exposes with a wildcard.

--- a/packaging/pep517_backend/_backend.py
+++ b/packaging/pep517_backend/_backend.py
@@ -10,9 +10,16 @@ from pathlib import Path
 
 from expandvars import expandvars
 from setuptools.build_meta import (  # noqa: F401  # Re-exporting PEP 517 hooks
-    build_sdist, build_wheel, get_requires_for_build_sdist,
-    get_requires_for_build_wheel, prepare_metadata_for_build_wheel,
+    build_wheel,
 )
+
+
+try:
+    from setuptools.build_meta import (  # noqa: WPS433
+        build_editable as _setuptools_build_editable,
+    )
+except ImportError:
+    _setuptools_build_editable = None  # noqa:WPS440
 
 
 # isort: split
@@ -180,3 +187,6 @@ def pre_build_cython(orig_func):  # noqa: WPS210
 build_wheel = convert_to_kwargs_only(  # pylint: disable=invalid-name
     pre_build_cython(build_wheel),
 )
+
+if _setuptools_build_editable is not None:
+    build_editable = build_wheel

--- a/packaging/pep517_backend/hooks.py
+++ b/packaging/pep517_backend/hooks.py
@@ -2,13 +2,18 @@
 
 """PEP 517 build backend pre-building Cython exts before setuptools."""
 
-from ._backend import (  # noqa: WPS436  # Re-exporting PEP 517 hooks
-    build_sdist, build_wheel, get_requires_for_build_sdist,
-    get_requires_for_build_wheel, prepare_metadata_for_build_wheel,
-)
+from contextlib import suppress as _suppress
+
+# Re-exporting PEP 517 hooks
+# pylint: disable-next=unused-wildcard-import,wildcard-import
+from setuptools.build_meta import *  # noqa: E501, F403, WPS347
+
+# Re-exporting PEP 517 hooks
+from ._backend import build_wheel  # noqa: WPS436
 
 
-__all__ = (  # noqa: WPS317, WPS410
-    'build_sdist', 'build_wheel', 'get_requires_for_build_sdist',
-    'get_requires_for_build_wheel', 'prepare_metadata_for_build_wheel',
-)
+with _suppress(ImportError):  # Only succeeds w/ setuptools implementing PEP 660
+    # Re-exporting PEP 660 hooks
+    from ._backend import (  # type: ignore[assignment]  # noqa: WPS433, WPS436
+        build_editable,
+    )


### PR DESCRIPTION
Previously, due to restrictive PEP 517 hook reimports, our in-tree build backend was losing non-PEP 517 hooks implemented in newer versions of `setuptools` but not the earlier ones. This is now addressed by reexporting everything that `setuptools` exposes with a wildcard.
