### PR TITLE
📝💅 Use tox to build docs on RTD

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,30 +4,26 @@
 
 ---
 
-# Required
+# RTD API version
 version: 2
-
-# Build documentation in the docs/ directory with Sphinx
-sphinx:
-  builder: dirhtml
-  configuration: docs/conf.py
-  fail_on_warning: true
-
-formats: []
-
-submodules:
-  include: all  # []
-  exclude: []
-  recursive: true
 
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: >-
+      3.10
+  commands:
+  - python -Im venv "${READTHEDOCS_VIRTUALENV_PATH}"
+  - >-
+    "${READTHEDOCS_VIRTUALENV_PATH}"/bin/python -Im
+    pip install tox
+  - >-
+    "${READTHEDOCS_VIRTUALENV_PATH}"/bin/python -Im
+    tox -e build-docs --notest -v
+  - >-
+    "${READTHEDOCS_VIRTUALENV_PATH}"/bin/python -Im
+    tox -e build-docs --skip-pkg-install -q
+    --
+    "${READTHEDOCS_OUTPUT}"/html
 
-# Optionally set the version of Python and requirements required
-# to build docs
-python:
-  install:
-  - requirements: docs/requirements.txt
 ...

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,7 +19,7 @@ build:
     pip install tox
   - >-
     "${READTHEDOCS_VIRTUALENV_PATH}"/bin/python -Im
-    tox -e build-docs --notest -v
+    tox -e build-docs --notest -vvvvv
   - >-
     "${READTHEDOCS_VIRTUALENV_PATH}"/bin/python -Im
     tox -e build-docs --skip-pkg-install -q

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -21,9 +21,9 @@ build:
     "${READTHEDOCS_VIRTUALENV_PATH}"/bin/python -Im
     tox -e build-docs --notest -vvvvv
   - >-
+    SPHINX_BUILDER=dirhtml
+    SPHINX_BUILD_OUTPUT_DIRECTORY="${READTHEDOCS_OUTPUT}"/html
     "${READTHEDOCS_VIRTUALENV_PATH}"/bin/python -Im
     tox -e build-docs --skip-pkg-install -q
-    --
-    "${READTHEDOCS_OUTPUT}"/html
 
 ...

--- a/tox.ini
+++ b/tox.ini
@@ -334,7 +334,7 @@ commands =
     -W --keep-going \
     -d "{temp_dir}/.doctrees" \
     . \
-    "{envdir}/docs_out"
+    {posargs:"{envdir}/docs_out"}
 
   # Print out the output docs dir and a way to serve html:
   -{envpython} -c\

--- a/tox.ini
+++ b/tox.ini
@@ -325,7 +325,7 @@ commands =
   -git fetch --tags
 
   # Build the html docs with Sphinx:
-  {envpython} -m sphinx \
+  {envpython} -Im sphinx \
   {posargs:\
     -j auto \
     -b {env:SPHINX_BUILDER:html} \
@@ -346,7 +346,7 @@ commands =
   print("\n" + "=" * 120 +\
   f"\n\nDocumentation available under:\n\n\
   \tfile://\{index_file\}\n\nTo serve docs, use\n\n\
-  \t$ python3 -m http.server --directory \
+  \t$ python3 -Im http.server --directory \
   \N\{QUOTATION MARK\}\{docs_dir\}\N\{QUOTATION MARK\} 0\n\n" +\
   "=" * 120)'
 changedir = {toxinidir}/docs

--- a/tox.ini
+++ b/tox.ini
@@ -326,15 +326,17 @@ commands =
 
   # Build the html docs with Sphinx:
   {envpython} -m sphinx \
+  {posargs:\
     -j auto \
-    -b html \
+    -b {env:SPHINX_BUILDER:html} \
     {tty:--color} \
     -a \
     -n \
     -W --keep-going \
     -d "{temp_dir}/.doctrees" \
     . \
-    {posargs:"{envdir}/docs_out"}
+    {env:SPHINX_BUILD_OUTPUT_DIRECTORY:"{envdir}/docs_out"} \
+  }
 
   # Print out the output docs dir and a way to serve html:
   -{envpython} -c\
@@ -350,6 +352,8 @@ commands =
 changedir = {toxinidir}/docs
 isolated_build = true
 passenv =
+  SPHINX_BUILDER
+  SPHINX_BUILD_OUTPUT_DIRECTORY
   SSH_AUTH_SOCK
 skip_install = true
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Previously, RTD used its own set of low-level commands to build the docs. This patch unifies the process, reusing what the contributors use locally and what's integrated in the CI.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request
- Maintenance Pull Request
