### PR TITLE
Fix the workflow location in the release doc

### DIFF
--- a/docs/changelog-fragments/565.contrib.rst
+++ b/docs/changelog-fragments/565.contrib.rst
@@ -1,0 +1,2 @@
+Fixed the location of release workflow in the
+:ref:`Release Guide` document -- by :user:`Qalthos`.

--- a/docs/contributing/release_guide.rst
+++ b/docs/contributing/release_guide.rst
@@ -86,4 +86,4 @@ The release stage
 
 
 .. _GitHub Actions CI/CD workflow:
-   https://github.com/ansible/pylibssh/actions/workflows/build-test-n-publish.yml
+   https://github.com/ansible/pylibssh/actions/workflows/ci-cd.yml


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
The Release Guide documentation points to a workflow that no longer exists. This fixes that link.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request
