### PR TITLE
Allow request_exec with async I/O and more

### DIFF
--- a/docs/_samples/shell.py
+++ b/docs/_samples/shell.py
@@ -25,7 +25,7 @@ print(f'{ssh.is_connected=}')
 if ssh.is_connected:
     ssh_channel = ssh.new_channel()
     try:
-        cmd_resp = ssh_channel.write(b'ls')
+        cmd_resp = ssh_channel.exec_command(b'ls')
         print(f'stdout:\n{cmd_resp.stdout}\n')
         print(f'stderr:\n{cmd_resp.stderr}\n')
         print(f'return code: {cmd_resp.returncode}\n')

--- a/docs/changelog-fragments/576.bugfix.rst
+++ b/docs/changelog-fragments/576.bugfix.rst
@@ -1,0 +1,7 @@
+|project| no longer crashes when received EOF or when channel is not explicitly
+closed -- by :user:`pbrezina`.
+
+Previously, |project| crashed if ``channel.recv`` was called and ``libssh``
+returned ``SSH_EOF`` error. It also crashed on some special occasions where
+channel was not explicitly closed and the session object was garbage-collected
+first.

--- a/docs/changelog-fragments/576.doc.rst
+++ b/docs/changelog-fragments/576.doc.rst
@@ -1,0 +1,4 @@
+Fixed the example of invoking remote commands by using
+``Channel.exec_command()`` in snippets -- by :user:`pbrezina`.
+
+Its previously showcased version wasn't functional.

--- a/docs/changelog-fragments/576.feature.rst
+++ b/docs/changelog-fragments/576.feature.rst
@@ -1,0 +1,7 @@
+The ``request_exec()`` method was added to the ``Channel`` class. It exposes an
+interface for calling the respective low-level C-API of the underlying
+``libssh`` library -- by :user:`pbrezina`.
+
+Additionally, the following calls to ``libssh`` are now available in the same
+class: ``request_exec()``, ``send_eof()``, ``request_send_signal()`` and
+``is_eof`` which is exposed as a :py:class:`property`.

--- a/src/pylibsshext/channel.pxd
+++ b/src/pylibsshext/channel.pxd
@@ -20,5 +20,6 @@ from pylibsshext.includes cimport callbacks, libssh
 
 
 cdef class Channel:
+    cdef  _session
     cdef libssh.ssh_channel _libssh_channel
     cdef libssh.ssh_session _libssh_session

--- a/src/pylibsshext/channel.pyx
+++ b/src/pylibsshext/channel.pyx
@@ -204,6 +204,12 @@ cdef class Channel:
     def get_channel_exit_status(self):
         return libssh.ssh_channel_get_exit_status(self._libssh_channel)
 
+    @property
+    def is_eof(self):
+        """True if remote has sent an EOF."""
+        rc = libssh.ssh_channel_is_eof(self._libssh_channel)
+        return rc != 0
+
     def close(self):
         if self._libssh_channel is not NULL:
             libssh.ssh_channel_close(self._libssh_channel)

--- a/src/pylibsshext/channel.pyx
+++ b/src/pylibsshext/channel.pyx
@@ -47,6 +47,7 @@ cdef int _process_outputs(libssh.ssh_session session,
 
 cdef class Channel:
     def __cinit__(self, session):
+        self._session = session
         self._libssh_session = get_libssh_session(session)
         self._libssh_channel = libssh.ssh_channel_new(self._libssh_session)
 

--- a/src/pylibsshext/channel.pyx
+++ b/src/pylibsshext/channel.pyx
@@ -70,6 +70,12 @@ cdef class Channel:
         if rc != libssh.SSH_OK:
             raise LibsshChannelException("Failed to request_shell: [%d]" % rc)
 
+    def request_exec(self, command):
+        """Run a shell command without an interactive shell."""
+        rc = libssh.ssh_channel_request_exec(self._libssh_channel, command.encode("utf-8"))
+        if rc != libssh.SSH_OK:
+            raise LibsshChannelException("Failed to request_exec: [%d]" % rc)
+
     def request_pty(self):
         rc = libssh.ssh_channel_request_pty(self._libssh_channel)
         if rc != libssh.SSH_OK:
@@ -169,6 +175,12 @@ cdef class Channel:
             libssh.ssh_channel_free(channel)
 
         return result
+
+    def send_eof(self):
+        """Send EOF to the channel, this will close stdin."""
+        rc = libssh.ssh_channel_send_eof(self._libssh_channel)
+        if rc != libssh.SSH_OK:
+            raise LibsshChannelException("Failed to ssh_channel_send_eof: [%d]" % rc)
 
     def get_channel_exit_status(self):
         return libssh.ssh_channel_get_exit_status(self._libssh_channel)

--- a/src/pylibsshext/channel.pyx
+++ b/src/pylibsshext/channel.pyx
@@ -110,6 +110,9 @@ cdef class Channel:
             # This is what Session._get_session_error_str() does, but we don't have the Python object
             error = libssh.ssh_get_error(<void*>self._libssh_session).decode()
             raise LibsshChannelReadFailure(error)
+        elif nbytes == libssh.SSH_EOF:
+            return None
+
         return <bytes>buffer[:nbytes]
 
     def recv(self, size=1024, stderr=0):

--- a/src/pylibsshext/includes/libssh.pxd
+++ b/src/pylibsshext/includes/libssh.pxd
@@ -214,6 +214,7 @@ cdef extern from "libssh/libssh.h" nogil:
     int ssh_channel_get_exit_status(ssh_channel channel)
     int ssh_channel_send_eof(ssh_channel channel)
     int ssh_channel_request_send_signal(ssh_channel channel, const char *sig)
+    int ssh_channel_is_eof(ssh_channel channel)
 
     int ssh_set_log_level(int level)
 

--- a/src/pylibsshext/includes/libssh.pxd
+++ b/src/pylibsshext/includes/libssh.pxd
@@ -213,6 +213,7 @@ cdef extern from "libssh/libssh.h" nogil:
     int ssh_channel_request_exec(ssh_channel channel, const char *cmd)
     int ssh_channel_get_exit_status(ssh_channel channel)
     int ssh_channel_send_eof(ssh_channel channel)
+    int ssh_channel_request_send_signal(ssh_channel channel, const char *sig)
 
     int ssh_set_log_level(int level)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -157,7 +157,7 @@ def ssh_authorized_keys_path(sshd_path, ssh_clientkey_path):
 
 
 @pytest.fixture
-def sshd_addr(free_port_num, ssh_authorized_keys_path, sshd_hostkey_path, sshd_path):
+def sshd_addr(free_port_num, ssh_authorized_keys_path, sshd_hostkey_path, sshd_path, ssh_clientkey_path):
     """Spawn an instance of sshd on a free port.
 
     :raises RuntimeError: If spawning SSHD failed.
@@ -198,7 +198,7 @@ def sshd_addr(free_port_num, ssh_authorized_keys_path, sshd_hostkey_path, sshd_p
     )
     proc = subprocess.Popen(cmd)
 
-    wait_for_svc_ready_state(hostname, free_port_num, b'SSH-2.0-OpenSSH_')
+    wait_for_svc_ready_state(hostname, free_port_num, ssh_clientkey_path)
 
     if proc.returncode:
         raise RuntimeError('sshd boom 💣')

--- a/tests/unit/channel_test.py
+++ b/tests/unit/channel_test.py
@@ -115,3 +115,15 @@ def test_send_signal(ssh_channel):
         rc = ssh_channel.get_channel_exit_status()
 
     assert rc == 1
+
+
+def test_recv_eof(ssh_channel):
+    """
+    Test that reading EOF does not raise error.
+
+    SystemError: Negative size passed to PyBytes_FromStringAndSize
+    """
+    ssh_channel.request_exec('exit 0')
+    ssh_channel.poll(timeout=POLL_TIMEOUT)
+    assert ssh_channel.is_eof
+    ssh_channel.recv()

--- a/tests/unit/channel_test.py
+++ b/tests/unit/channel_test.py
@@ -127,3 +127,10 @@ def test_recv_eof(ssh_channel):
     ssh_channel.poll(timeout=POLL_TIMEOUT)
     assert ssh_channel.is_eof
     ssh_channel.recv()
+
+
+def test_is_eof(ssh_channel):
+    """Test that EOF-state is correctly obtained with is_eof."""
+    ssh_channel.request_exec('exit 0')
+    ssh_channel.poll(timeout=POLL_TIMEOUT)
+    assert ssh_channel.is_eof


### PR DESCRIPTION
This PR add calls to ``libssh`` ``request_exec()`` and relevant functions in order
to allow non-blocking async I/O. I need this to replace ``parallel-ssh`` which
unfortunately became a dead project, incompatible with Python 3.12+.

Additionally, it adds call to ``libssh`` ``request_send_signal()`` which allows to
send signals to the remote process if SSH server supports it.

I also fixed few bugs that I stumbled upon.


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
$sbj.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
N/A