### PR TITLE
Fix the log levels mapping

### DIFF
--- a/docs/_samples/logging.py
+++ b/docs/_samples/logging.py
@@ -1,0 +1,38 @@
+import logging
+
+from pylibsshext.errors import LibsshSessionException
+from pylibsshext.logging import ANSIBLE_PYLIBSSH_TRACE
+from pylibsshext.session import Session
+
+
+HOST = 'CHANGEME'
+USER = 'CHANGEME'
+PASSWORD = 'CHANGEME'
+PORT = 22
+
+# Initializes the new TRACE log level in python logging system
+ssh = Session()
+
+error_handler = logging.StreamHandler()
+error_handler.setLevel(logging.ERROR)
+
+debug_handler = logging.FileHandler('ansible-libssh-errors.log')
+debug_handler.setLevel(ANSIBLE_PYLIBSSH_TRACE)
+
+logging.getLogger('ansible-pylibssh').addHandler(error_handler)
+logging.getLogger('ansible-pylibssh').addHandler(debug_handler)
+
+# Set log level on session to filter log messages libssh emits internally
+# and sends over into the Python land (when performance matters)
+ssh.set_log_level(ANSIBLE_PYLIBSSH_TRACE)
+
+try:
+    ssh.connect(
+        host=HOST,
+        user=USER,
+        password=PASSWORD,
+        port=PORT,
+    )
+except LibsshSessionException as ssh_exc:
+    # NOTE: `connect()` above will emit its own detailed logs from `libssh`
+    print(f'Failed to connect to {HOST}:{PORT} over SSH: {ssh_exc!s}')

--- a/docs/changelog-fragments/597.bugfix.rst
+++ b/docs/changelog-fragments/597.bugfix.rst
@@ -1,0 +1,6 @@
+Fixed the log level mapping to cover the entire ``libssh`` range
+-- by :user:`Jakuje` and :user:`webknjaz`.
+
+Previously it was not possible to set the most verbose ``libssh`` log level
+``SSH_LOG_TRACE`` to get the most verbose log messages useful for debugging
+connection issues.

--- a/docs/changelog-fragments/597.feature.rst
+++ b/docs/changelog-fragments/597.feature.rst
@@ -1,0 +1,29 @@
+Made ``libssh`` use the Python :external+python:mod:`logging` system
+-- by :user:`Jakuje` and :user:`webknjaz`.
+
+Previously the underlying ``libssh`` library was writing its logs directly
+from the C-level into ``stderr``, which caused inconsistent behavior.
+
+The default log level is now set to :data:`ANSIBLE_PYLIBSSH_TRACE`
+and the downstream loggers are able to trim the verbosity down.
+If you need performance, it is possible to disable logging on the ``libssh``
+side at the source by setting a lower logging value, for example:
+
+.. code-block:: python
+
+   ssh_session.set_log_level(ANSIBLE_PYLIBSSH_NOLOG)
+
+Additionally, the log level can be now be set also through the session initializer:
+
+.. code-block:: python
+
+   ssh = Session(log_verbosity=ANSIBLE_PYLIBSSH_TRACE)
+
+
+or the ``connect()`` method arguments:
+
+.. code-block:: python
+
+   ssh.connect(log_verbosity=ANSIBLE_PYLIBSSH_TRACE)
+
+Setting any levels imported from :external+python:mod:`!logging` is also supported.

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -67,6 +67,45 @@ service principals may be specified.
    :dedent: 4
 
 
+Logging events
+==============
+
+The |project| is passing all the ``libssh`` log messages into the Python
+:external+python:mod:`logging` subsystem by default. This is initialized when new
+session is created during the ``Session`` initialization.
+
+You can configure your loggers and handlers as in any other Python
+project. The |project| Logger name is ``'ansible-pylibssh'``.
+
+.. literalinclude:: _samples/logging.py
+   :language: python
+   :start-at: ssh = Session()
+   :end-before: # Set log level on session
+   :emphasize-lines: 1
+
+.. attention::
+
+    When performance is critical, you can use the
+    ``Session.set_log_level(ANSIBLE_PYLIBSSH_NOLOG)``
+    API to prevent ``libssh`` from emitting the log messages at the source.
+    Note that it is different from :data:`logging.NOTSET` which has
+    the opposite semantics.
+
+In addition to standard Python :external+python:mod:`logging` levels, the |project| supports
+two special levels:
+
+.. data:: ANSIBLE_PYLIBSSH_NOLOG
+
+    Indicates that |project| will not emit any events into the
+    :external+python:mod:`logging` subsystem.
+
+.. data:: ANSIBLE_PYLIBSSH_TRACE
+
+    Indicates that |project| will make all possible logs available
+    to the :external+python:mod:`logging` subsystem, generally useful for debugging low-level
+    libssh operations.
+
+
 Passing a command and reading response
 ======================================
 

--- a/src/pylibsshext/includes/callbacks.pxd
+++ b/src/pylibsshext/includes/callbacks.pxd
@@ -127,3 +127,10 @@ cdef extern from "libssh/callbacks.h":
     ctypedef ssh_channel_callbacks_struct * ssh_channel_callbacks
 
     int ssh_set_channel_callbacks(ssh_channel channel, ssh_channel_callbacks cb)
+
+    ctypedef void(*ssh_logging_callback)(
+        int priority,
+        const char *function,
+        const char *buffer,
+        void *userdata)
+    int ssh_set_log_callback(ssh_logging_callback cb)

--- a/src/pylibsshext/logging.pxd
+++ b/src/pylibsshext/logging.pxd
@@ -1,0 +1,22 @@
+# distutils: libraries = ssh
+#
+# This file is part of the ansible-pylibssh library
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, see file LICENSE.rst in this
+# repository.
+
+"""
+The logging module of ``ansible-pylibssh`` provides interface between libssh
+logging and Python :external+python:mod:`logging` facility.
+"""

--- a/src/pylibsshext/logging.pyx
+++ b/src/pylibsshext/logging.pyx
@@ -1,0 +1,133 @@
+#
+# This file is part of the ansible-pylibssh library
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, see file LICENSE.rst in this
+# repository.
+
+"""
+The logging module of ``ansible-pylibssh`` provides interface between libssh
+logging and Python :external+python:mod:`logging` facility.
+
+It provides two new log levels, that can be used with to set the log verbosity
+using ``set_log_level()`` method on ``Session`` object.
+
+.. data:: ANSIBLE_PYLIBSSH_NOLOG
+
+    Indicates that ``ansible-pylibssh`` will not emit any events into the
+    :external+python:mod:`logging` subsystem.
+
+.. data:: ANSIBLE_PYLIBSSH_TRACE
+
+    Indicates that ``ansible-pylibssh`` will make all possible logs available
+    to the :external+python:mod:`logging` subsystem, generally useful for
+    debugging low-level libssh operations.
+
+The default log level is set to the ``ANSIBLE_PYLIBSSH_TRACE``, which means
+all the messages are fed into the python. Setting different levels from
+the above lost or any value from Python :external+python:mod:`logging` module
+will allow prevent libssh emitting these logs.
+"""
+
+import logging
+
+from pylibsshext.errors cimport LibsshSessionException
+from pylibsshext.includes cimport callbacks, libssh
+
+
+ANSIBLE_PYLIBSSH_NOLOG = logging.FATAL * 2
+ANSIBLE_PYLIBSSH_TRACE = int(logging.DEBUG / 2)
+
+LOG_MAP = {
+    ANSIBLE_PYLIBSSH_TRACE: libssh.SSH_LOG_TRACE,
+    logging.DEBUG: libssh.SSH_LOG_DEBUG,
+    logging.INFO: libssh.SSH_LOG_INFO,
+    logging.WARNING: libssh.SSH_LOG_WARN,
+    ANSIBLE_PYLIBSSH_NOLOG: libssh.SSH_LOG_NONE,
+}
+
+LOG_MAP_REV = {
+    **{
+        libssh_name: py_name
+        for py_name, libssh_name in LOG_MAP.items()
+    },
+}
+
+# mapping aliases
+LOG_MAP[logging.NOTSET] = libssh.SSH_LOG_TRACE
+LOG_MAP[logging.ERROR] = libssh.SSH_LOG_WARN
+LOG_MAP[logging.CRITICAL] = libssh.SSH_LOG_WARN
+
+
+def _add_trace_log_level():
+    """
+    Add a trace log level to the Python :external+python:mod:`logging` system.
+    """
+    level_num = ANSIBLE_PYLIBSSH_TRACE
+    level_name = "TRACE"
+
+    logging.addLevelName(level_num, level_name)
+
+
+cdef void _pylibssh_log_wrapper(int priority,
+                                const char *function,
+                                const char *buffer,
+                                void *userdata) noexcept:
+    log_level = LOG_MAP_REV[priority]
+    logging.getLogger("ansible-pylibssh").log(log_level, buffer.decode('utf-8'))
+
+
+def _set_log_callback():
+    """
+    Set libssh logging callback
+
+    Our function redirects the messages to python
+    :external+python:mod:`logging` facility.
+    """
+    # Note, that we could also set the set_log_userdata() to access the logger
+    # object, but I did not find it much useful when it is global already.
+    callbacks.ssh_set_log_callback(_pylibssh_log_wrapper)
+
+
+def _initialize_logging():
+    """
+    Initialize libssh logging subsystem
+
+    This is implemenbed by adding our own log level and registering our callback
+    with libssh.
+    """
+    # This is done globally, as the libssh logging is not tied to specific
+    # session (its thread-local state in libssh) so either very good care
+    # needs to be taken to make sure the logger is in place when callback
+    # can be called almost from anywhere in the code or just keep it global.
+    _add_trace_log_level()
+    _set_log_callback()
+
+
+def _set_level(level):
+    """
+    Set logging level to the given value from ``LOG_MAP``.
+
+    :param level: The level to set.
+    :type level: int
+
+    :raises LibsshSessionException: If the log level is not known to libssh or pylibssh.
+
+    :returns: Nothing.
+    :rtype: None
+    """
+    if level not in LOG_MAP:
+        raise LibsshSessionException(f'Invalid log level [{level:d}]')
+
+    # can never fail for valid values from the map
+    libssh.ssh_set_log_level(LOG_MAP[level])

--- a/src/pylibsshext/session.pyx
+++ b/src/pylibsshext/session.pyx
@@ -41,6 +41,7 @@ OPTS_MAP = {
     "gssapi_server_identity": libssh.SSH_OPTIONS_GSSAPI_SERVER_IDENTITY,
     "gssapi_client_identity": libssh.SSH_OPTIONS_GSSAPI_CLIENT_IDENTITY,
     "gssapi_delegate_credentials": libssh.SSH_OPTIONS_GSSAPI_DELEGATE_CREDENTIALS,
+    "log_verbosity": libssh.SSH_OPTIONS_LOG_VERBOSITY,
 }
 OPTS_DIR_MAP = {
     "ssh_dir": libssh.SSH_OPTIONS_SSH_DIR,
@@ -165,7 +166,7 @@ cdef class Session(object):
             key_m = OPTS_MAP[key]
         else:
             raise LibsshSessionException("Unknown attribute name [%s]" % key)
-        if key in ("fd", "gssapi_delegate_credentials"):
+        if key in ("fd", "gssapi_delegate_credentials", "log_verbosity"):
             value_int = value
             libssh.ssh_options_set(self._libssh_session, key_m, &value_int)
         elif key == "port":
@@ -248,6 +249,13 @@ cdef class Session(object):
         :param proxycommand: The proxycommand use to setup a ssh connection using
         jumphost
         :type proxycommand: str
+
+        :param log_verbosity: The log level to set filtering on source. Possible values are
+                              :data:`ANSIBLE_PYLIBSSH_TRACE`, :data:`logging.DEBUG`,
+                              :data:`logging.INFO`, :data:`logging.WARNING`,
+                              :data:`logging.ERROR`, :data:`logging.FATAL`,
+                              :data:`ANSIBLE_PYLIBSSH_NOLOG`.
+        :type log_verbosity: int
         """
         cdef LibsshSessionException saved_exception = None
 

--- a/src/pylibsshext/session.pyx
+++ b/src/pylibsshext/session.pyx
@@ -21,6 +21,7 @@ from cpython.bytes cimport PyBytes_AS_STRING
 
 from pylibsshext.channel import Channel
 from pylibsshext.errors cimport LibsshSessionException
+from pylibsshext.logging import _initialize_logging, _set_level
 from pylibsshext.scp import SCP
 from pylibsshext.sftp import SFTP
 
@@ -44,15 +45,6 @@ OPTS_MAP = {
 OPTS_DIR_MAP = {
     "ssh_dir": libssh.SSH_OPTIONS_SSH_DIR,
     "add_identity": libssh.SSH_OPTIONS_ADD_IDENTITY,
-}
-
-LOG_MAP = {
-    logging.NOTSET: libssh.SSH_LOG_NONE,
-    logging.DEBUG: libssh.SSH_LOG_DEBUG,
-    logging.INFO: libssh.SSH_LOG_INFO,
-    logging.WARNING: libssh.SSH_LOG_WARN,
-    logging.ERROR: libssh.SSH_LOG_WARN,
-    logging.CRITICAL: libssh.SSH_LOG_TRACE
 }
 
 KNOW_HOST_MSG_MAP = {
@@ -114,6 +106,8 @@ cdef class Session(object):
         # the callbacks to be around even after we free the underlying channels so
         # we should free them only when we terminate the session.
         self._channel_callbacks = []
+        _initialize_logging()
+        _set_level(logging.NOTSET)
 
     def __cinit__(self, host=None, **kwargs):
         self._libssh_session = libssh.ssh_new()
@@ -541,12 +535,7 @@ cdef class Session(object):
         return SFTP(self)
 
     def set_log_level(self, level):
-        if level in LOG_MAP.keys():
-            rc = libssh.ssh_set_log_level(LOG_MAP[level])
-            if rc != libssh.SSH_OK:
-                raise LibsshSessionException("Failed to set log level [%d] with error [%d]" % (level, rc))
-        else:
-            raise LibsshSessionException("Invalid log level [%d]" % level)
+        _set_level(level)
 
     def close(self):
         if self._libssh_session is not NULL:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,9 +15,21 @@ from _service_utils import (
 
 from pylibsshext.session import Session
 
+from pylibsshext import __libssh_version__
+
 
 _DIR_PRIV_RW_OWNER = 0o700
 _FILE_PRIV_RW_OWNER = 0o600
+
+
+@pytest.fixture
+def libssh_version_tuple():
+    """
+    Get the libssh version as a tuple of (major, minor, patch).
+
+    This is useful for simple comparison and conditioning tests based on this value.
+    """
+    return tuple(map(int, (__libssh_version__.split('.'))))
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@
 
 """Pytest plugins and fixtures configuration."""
 
-import logging
 import shutil
 import socket
 import subprocess
@@ -117,8 +116,6 @@ def ssh_client_session(ssh_session_connect):
     # noqa: DAR101
     """
     ssh_session = Session()
-    # TODO Adjust when #597 will be merged
-    ssh_session.set_log_level(logging.CRITICAL)
     ssh_session_connect(ssh_session)
     try:  # noqa: WPS501
         yield ssh_session

--- a/tests/integration/logging_test.py
+++ b/tests/integration/logging_test.py
@@ -137,3 +137,17 @@ def test_session_log_level_bad():
     error_msg = r'^Invalid log level \[99\]$'
     with pytest.raises(LibsshSessionException, match=error_msg):
         ssh_session.set_log_level(BAD_LOG_LEVEL)
+
+
+def test_session_log_verbosity_session(
+    caplog: pytest.LogCaptureFixture,
+    free_port_num: int,
+) -> None:
+    """Test setting the log level through the Session initializer."""
+    ssh_session = Session(log_verbosity=ANSIBLE_PYLIBSSH_TRACE)
+
+    with _ctx.suppress(LibsshSessionException):
+        ssh_session.connect(host=LOCALHOST, port=free_port_num)
+
+    expected_poll_message = 'ssh_socket_pollcallback: Poll callback on socket'
+    assert expected_poll_message in caplog.text

--- a/tests/integration/logging_test.py
+++ b/tests/integration/logging_test.py
@@ -1,0 +1,139 @@
+"""Tests suite for logging."""
+
+import contextlib as _ctx
+import logging
+
+import pytest
+
+from pylibsshext.errors import LibsshSessionException
+from pylibsshext.logging import ANSIBLE_PYLIBSSH_NOLOG, ANSIBLE_PYLIBSSH_TRACE
+from pylibsshext.session import Session
+
+
+LOCALHOST = '127.0.0.1'
+BAD_LOG_LEVEL = 99
+
+
+@pytest.fixture(autouse=True)
+def _only_capture_project_logs(caplog: pytest.LogCaptureFixture) -> None:
+    """Hide unrelated log entries from capture."""
+    caplog.set_level(
+        ANSIBLE_PYLIBSSH_NOLOG + 1,
+    )  # suppress other loggers on the root level
+    caplog.set_level(
+        # NOTE: logging.NOTSET is unfit because it delegates to the root logger
+        ANSIBLE_PYLIBSSH_TRACE - 1,  # capture beyond everything
+        logger='ansible-pylibssh',
+    )  # don't block things early
+    caplog.clear()
+
+
+def test_session_log_level_warning(
+    caplog: pytest.LogCaptureFixture,
+    free_port_num: int,
+    libssh_version_tuple,
+) -> None:
+    """
+    Test setting the log level to WARNING.
+
+    It should show "Connection refused" on libssh 0.11.0 and newer.
+    But no debug/ainfo/trace messages.
+    """
+    ssh_session = Session()
+    ssh_session.set_log_level(logging.WARNING)
+
+    # the connection will fail but first log lands before that
+    with _ctx.suppress(LibsshSessionException):
+        ssh_session.connect(host=LOCALHOST, port=free_port_num)
+
+    log_records = caplog.records
+
+    # This message is available only in libssh 0.11.0 and newer
+    expected_substring = 'ssh_client_connection_callback: Connection refused'
+    if libssh_version_tuple >= (0, 11, 0):
+        assert any(
+            record.levelname == 'WARNING' and expected_substring in record.msg
+            for record in log_records
+        )
+
+    # No INFO and higher log messages should show up at this log level
+    forbidden_levels = {logging.INFO, logging.DEBUG, ANSIBLE_PYLIBSSH_TRACE}
+    captured_levels = {record.levelno for record in log_records}
+    assert forbidden_levels.isdisjoint(captured_levels)
+
+
+def test_session_log_level_debug(
+    caplog: pytest.LogCaptureFixture,
+    free_port_num: int,
+) -> None:
+    """
+    Test setting the log level to DEBUG.
+
+    It should reveal copyright information. But no trace messages.
+    """
+    ssh_session = Session()
+    ssh_session.set_log_level(logging.DEBUG)
+
+    # the connection will fail but first log lands before that
+    with _ctx.suppress(LibsshSessionException):
+        ssh_session.connect(host=LOCALHOST, port=free_port_num)
+
+    log_records = caplog.records
+
+    expected_copyright_substring = 'and libssh contributors.'
+    # This log message is shown at different log levels
+    # in different libssh versions. Changed at 657d9143d1 (before 0.11.0)
+    # but backported to some RHEL9 versions so matching on the libssh version
+    # is not reliable.
+    assert any(
+        record.levelname in {'DEBUG', 'INFO'}
+        and expected_copyright_substring in record.msg
+        for record in log_records
+    )
+
+    assert 'TRACE' not in (record.levelname for record in log_records)
+
+
+def test_session_log_level_no_log(
+    caplog: pytest.LogCaptureFixture,
+    free_port_num: int,
+) -> None:
+    """Test setting the log level to NOLOG should be quiet."""
+    ssh_session = Session()
+    ssh_session.set_log_level(ANSIBLE_PYLIBSSH_NOLOG)
+
+    # the connection will fail but first log lands before that
+    with _ctx.suppress(LibsshSessionException):
+        ssh_session.connect(host=LOCALHOST, port=free_port_num)
+
+    assert not caplog.records
+
+
+@pytest.mark.parametrize(
+    'log_level',
+    (ANSIBLE_PYLIBSSH_TRACE, logging.NOTSET),
+    ids=('TRACE', 'NOTSET'),
+)
+def test_session_log_level_trace(
+    caplog: pytest.LogCaptureFixture,
+    free_port_num: int,
+    log_level: int,
+) -> None:
+    """Test setting the most detailed log level provides all the logs."""
+    ssh_session = Session()
+    ssh_session.set_log_level(log_level)
+
+    with _ctx.suppress(LibsshSessionException):
+        ssh_session.connect(host=LOCALHOST, port=free_port_num)
+
+    expected_poll_message = 'ssh_socket_pollcallback: Poll callback on socket'
+    assert expected_poll_message in caplog.text
+
+
+def test_session_log_level_bad():
+    """Test that setting the log level to an unsupported value is rejected."""
+    ssh_session = Session()
+
+    error_msg = r'^Invalid log level \[99\]$'
+    with pytest.raises(LibsshSessionException, match=error_msg):
+        ssh_session.set_log_level(BAD_LOG_LEVEL)


### PR DESCRIPTION
##### SUMMARY
The libssh provides the most verbose logging with SSH_LOG_TRACE, which was mapped to `logging.CRITICAL`, causing the users being unable to get full debug logs. These are critical for libssh developers to be able to investigate issues.

##### ISSUE TYPE
- Bugfix Pull Request