### PR TITLE
⇪ Bump the `setuptools-scm` pin to v8.1.0

### DIFF
--- a/docs/changelog-fragments/601.contrib.rst
+++ b/docs/changelog-fragments/601.contrib.rst
@@ -1,0 +1,1 @@
+601.packaging.rst

--- a/docs/changelog-fragments/601.packaging.rst
+++ b/docs/changelog-fragments/601.packaging.rst
@@ -1,0 +1,5 @@
+The ``setuptools-scm`` build dependency CI pin was updated to 8.1.0 —
+this version fixes a date parsing incompatibility introduced by Git 2.45.0
+(:gh:`pypa/setuptools_scm#1039 <pypa/setuptools_scm/issues/1038>`,
+:gh:`pypa/setuptools_scm#1038 <pypa/setuptools_scm/pull/1039>`)
+-- by :user:`webknjaz`.

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -14,7 +14,7 @@ pyparsing==3.0.9
     # via packaging
 setuptools-scm==6.4.2 ; python_version < "3.7"
 setuptools-scm==7.1.0 ; python_version == "3.7.*"
-setuptools-scm==8.0.4 ; python_version > "3.7"
+setuptools-scm==8.1.0 ; python_version > "3.7"
     # via -r -
 setuptools-scm-git-archive==1.4 ; python_version < "3.7"
     # via -r -


### PR DESCRIPTION
This is necessary to let it deal with the datetime output format that versions of Git 2.45.0 and above now produce.

Refs:
* https://github.com/pypa/setuptools_scm/issues/1038
* https://github.com/pypa/setuptools_scm/pull/1039

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Packaging Pull Request