### PR TITLE
🧪 Make post-gate job chain run on gate success

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1540,7 +1540,9 @@ jobs:
     - check
     - pre-setup  # transitive, for accessing settings
     if: >-
-      fromJSON(needs.pre-setup.outputs.release-requested)
+      always()
+      && needs.check.result == 'success'
+      && fromJSON(needs.pre-setup.outputs.release-requested)
     runs-on: ubuntu-latest
 
     environment:
@@ -1570,8 +1572,12 @@ jobs:
     - check
     - pre-setup  # transitive, for accessing settings
     if: >-
-      fromJSON(needs.pre-setup.outputs.is-untagged-devel)
-      || fromJSON(needs.pre-setup.outputs.release-requested)
+      always()
+      && needs.check.result == 'success'
+      && (
+        fromJSON(needs.pre-setup.outputs.is-untagged-devel)
+        || fromJSON(needs.pre-setup.outputs.release-requested)
+      )
     runs-on: ubuntu-latest
 
     environment:
@@ -1604,6 +1610,9 @@ jobs:
     needs:
     - publish-pypi
     - pre-setup  # transitive, for accessing settings
+    if: >-
+      always()
+      && needs.publish-pypi.result == 'success'
     runs-on: ubuntu-latest
 
     steps:
@@ -1695,6 +1704,9 @@ jobs:
     needs:
     - post-release-repo-update
     - pre-setup  # transitive, for accessing settings
+    if: >-
+      always()
+      && needs.post-release-repo-update.result == 'success'
     runs-on: ubuntu-latest
 
     permissions:
@@ -1782,8 +1794,12 @@ jobs:
     - check
     - pre-setup  # transitive, for accessing settings
     if: >-
-      fromJSON(needs.pre-setup.outputs.is-untagged-devel) ||
-      fromJSON(needs.pre-setup.outputs.release-requested)
+      always()
+      && needs.check.result == 'success'
+      && (
+        fromJSON(needs.pre-setup.outputs.is-untagged-devel) ||
+        fromJSON(needs.pre-setup.outputs.release-requested)
+      )
     runs-on: ubuntu-latest
 
     environment:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1540,7 +1540,7 @@ jobs:
     - check
     - pre-setup  # transitive, for accessing settings
     if: >-
-      always()
+      !cancelled()
       && ! (
         contains(needs.*.result, 'skipped')
         || contains(needs.*.result, 'failure')
@@ -1575,7 +1575,7 @@ jobs:
     - check
     - pre-setup  # transitive, for accessing settings
     if: >-
-      always()
+      !cancelled()
       && ! (
         contains(needs.*.result, 'skipped')
         || contains(needs.*.result, 'failure')
@@ -1806,7 +1806,7 @@ jobs:
     - check
     - pre-setup  # transitive, for accessing settings
     if: >-
-      always()
+      !cancelled()
       && ! (
         contains(needs.*.result, 'skipped')
         || contains(needs.*.result, 'failure')

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1541,7 +1541,10 @@ jobs:
     - pre-setup  # transitive, for accessing settings
     if: >-
       always()
-      && needs.check.result == 'success'
+      && ! (
+        contains(needs.*.result, 'skipped')
+        || contains(needs.*.result, 'failure')
+      )
       && fromJSON(needs.pre-setup.outputs.release-requested)
     runs-on: ubuntu-latest
 
@@ -1573,7 +1576,10 @@ jobs:
     - pre-setup  # transitive, for accessing settings
     if: >-
       always()
-      && needs.check.result == 'success'
+      && ! (
+        contains(needs.*.result, 'skipped')
+        || contains(needs.*.result, 'failure')
+      )
       && (
         fromJSON(needs.pre-setup.outputs.is-untagged-devel)
         || fromJSON(needs.pre-setup.outputs.release-requested)
@@ -1612,7 +1618,10 @@ jobs:
     - pre-setup  # transitive, for accessing settings
     if: >-
       always()
-      && needs.publish-pypi.result == 'success'
+      && ! (
+        contains(needs.*.result, 'skipped')
+        || contains(needs.*.result, 'failure')
+      )
     runs-on: ubuntu-latest
 
     steps:
@@ -1706,7 +1715,10 @@ jobs:
     - pre-setup  # transitive, for accessing settings
     if: >-
       always()
-      && needs.post-release-repo-update.result == 'success'
+      && ! (
+        contains(needs.*.result, 'skipped')
+        || contains(needs.*.result, 'failure')
+      )
     runs-on: ubuntu-latest
 
     permissions:
@@ -1795,7 +1807,10 @@ jobs:
     - pre-setup  # transitive, for accessing settings
     if: >-
       always()
-      && needs.check.result == 'success'
+      && ! (
+        contains(needs.*.result, 'skipped')
+        || contains(needs.*.result, 'failure')
+      )
       && (
         fromJSON(needs.pre-setup.outputs.is-untagged-devel) ||
         fromJSON(needs.pre-setup.outputs.release-requested)

--- a/docs/changelog-fragments/602.contrib.rst
+++ b/docs/changelog-fragments/602.contrib.rst
@@ -1,0 +1,6 @@
+The CI/CD configuration was fixed to allow publishing
+to PyPI and other targets disregarding the test stage
+outcome. This used to be a bug in the workflow definition
+that has now been fixed.
+
+-- by :user:`pbrezina` and :user:`webknjaz`


### PR DESCRIPTION
Previously, jobs following the `check` job didn't have `if` conditionals
or the existing expressions didn't use the status check functions. Those
jobs are responsible for the finishing steps of the release automation.
They used to work when the entire parent job tree was successful. The
release automation is triggered by the `workflow_dispatch` event, which
has a boolean flag/checkbox for disregarding the testing stage status.
Using it makes the `check` gate pass even when some test matrix jobs
fail. It was not obvious that jobs the depend on `check` don't run if
any of the parent chain jobs fail. Not by default, so they were being
skipped for no obvious reason.

This patch updates said `if` conditionals to force GitHub Actions CI/CD
to only take into account the `check` job result and not its
dependencies by prepending the trick of
`always() && needs.check.result == 'success' &&` in front of each `if`
conditional in publishing jobs.

Refs:
* actions/runner#2205 (comment)
* https://github.com/orgs/community/discussions/45058#discussioncomment-7465690
* https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions

Co-Authored-By: Pavel Březina <pbrezina@redhat.com>

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Maintenance Pull Request
- Testing Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
N/A