### PR TITLE
Do not crash if remote file does not exist

### DIFF
--- a/docs/changelog-fragments/208.bugfix.rst
+++ b/docs/changelog-fragments/208.bugfix.rst
@@ -1,0 +1,1 @@
+620.bugfix.rst

--- a/docs/changelog-fragments/325.bugfix.rst
+++ b/docs/changelog-fragments/325.bugfix.rst
@@ -1,0 +1,1 @@
+620.bugfix.rst

--- a/docs/changelog-fragments/620.bugfix.rst
+++ b/docs/changelog-fragments/620.bugfix.rst
@@ -1,0 +1,1 @@
+Downloading non-existent remote files via SCP no longer crashes the program -- by :user:`Jakuje`.

--- a/src/pylibsshext/scp.pyx
+++ b/src/pylibsshext/scp.pyx
@@ -96,7 +96,7 @@ cdef class SCP:
         :param local_file: The path on the local host where the file should be placed
         :type local_file: str
         """
-        cdef char *read_buffer
+        cdef char *read_buffer = NULL
 
         remote_file_b = remote_file
         if isinstance(remote_file_b, unicode):

--- a/tests/unit/scp_test.py
+++ b/tests/unit/scp_test.py
@@ -70,7 +70,7 @@ def path_to_non_existent_src_file(tmp_path):
     return path
 
 
-def test_get_missing_src(path_to_non_existent_src_file, ssh_scp):
+def test_copy_from_non_existent_remote_path(path_to_non_existent_src_file, ssh_scp):
     """Check that SCP file download raises exception if the remote file is missing."""
     error_msg = '^Error receiving information about file:'
     with pytest.raises(LibsshSCPException, match=error_msg):

--- a/tests/unit/scp_test.py
+++ b/tests/unit/scp_test.py
@@ -62,15 +62,15 @@ def test_get(dst_path, src_path, ssh_scp, transmit_payload):
 
 
 @pytest.fixture
-def src_path_missing(tmp_path):
+def path_to_non_existent_src_file(tmp_path):
     """Return a remote path that does not exist."""
     path = tmp_path / 'non-existing.txt'
     assert not path.exists()
     return path
 
 
-def test_get_missing_src(dst_path, src_path_missing, ssh_scp):
+def test_get_missing_src(dst_path, path_to_non_existent_src_file, ssh_scp):
     """Check that SCP file download raises exception if the remote file is missing."""
     error_msg = '^Error receiving information about file:'
     with pytest.raises(LibsshSCPException, match=error_msg):
-        ssh_scp.get(str(src_path_missing), str(dst_path))
+        ssh_scp.get(str(path_to_non_existent_src_file), str(dst_path))

--- a/tests/unit/scp_test.py
+++ b/tests/unit/scp_test.py
@@ -2,6 +2,7 @@
 
 """Tests suite for scp."""
 
+import os
 import uuid
 
 import pytest
@@ -69,8 +70,8 @@ def path_to_non_existent_src_file(tmp_path):
     return path
 
 
-def test_get_missing_src(dst_path, path_to_non_existent_src_file, ssh_scp):
+def test_get_missing_src(path_to_non_existent_src_file, ssh_scp):
     """Check that SCP file download raises exception if the remote file is missing."""
     error_msg = '^Error receiving information about file:'
     with pytest.raises(LibsshSCPException, match=error_msg):
-        ssh_scp.get(str(path_to_non_existent_src_file), str(dst_path))
+        ssh_scp.get(str(path_to_non_existent_src_file), os.devnull)


### PR DESCRIPTION
##### SUMMARY
The uninitialized pointer caused pylibssh crashing when the `scp.get()` failed in the first invocation of  `libssh.ssh_scp_pull_request()` (generally when the remote file did not exist, or it was not possible to read it for some reason).

This is the full log from libssh when pytest is executed directly with the `-s` argument:
```console
[2024/06/21 16:04:37.620775, 2] ssh_scp_pull_request:  Received SCP request: 'scp: /tmp/pytest-of-jjelen/pytest-22/popen-gw1/test_get_missing_src0/non-existing.txt: No such file or directory'
[2024/06/21 16:04:37.620779, 1] ssh_scp_pull_request:  SCP: Warning: scp: /tmp/pytest-of-jjelen/pytest-22/popen-gw1/test_get_missing_src0/non-existing.txt: No such file or directory
free(): invalid pointer
Fatal Python error: Aborted
```
(running the test from tox showed just the last line with pytest crashing)

Fixes #208
Fixes #325

##### ISSUE TYPE
- Bugfix Pull Request