### PR TITLE
Fix reading large files over SCP

### DIFF
--- a/docs/changelog-fragments/621.bugfix.rst
+++ b/docs/changelog-fragments/621.bugfix.rst
@@ -1,0 +1,1 @@
+Downloading files larger than 64kB over SCP no longer fails -- by :user:`Jakuje`.

--- a/tests/unit/scp_test.py
+++ b/tests/unit/scp_test.py
@@ -75,3 +75,17 @@ def test_copy_from_non_existent_remote_path(path_to_non_existent_src_file, ssh_s
     error_msg = '^Error receiving information about file:'
     with pytest.raises(LibsshSCPException, match=error_msg):
         ssh_scp.get(str(path_to_non_existent_src_file), os.devnull)
+
+
+@pytest.fixture
+def pre_existing_file_path(tmp_path):
+    """Return local path for a pre-populated file."""
+    path = tmp_path / 'pre-existing-file.txt'
+    path.write_bytes(b'whatever')
+    return path
+
+
+def test_get_existing_local(pre_existing_file_path, src_path, ssh_scp, transmit_payload):
+    """Check that SCP file download works and overwrites local file if it exists."""
+    ssh_scp.get(str(src_path), str(pre_existing_file_path))
+    assert pre_existing_file_path.read_bytes() == transmit_payload

--- a/tests/unit/scp_test.py
+++ b/tests/unit/scp_test.py
@@ -105,7 +105,12 @@ def large_payload():
 
 @pytest.fixture
 def src_path_large(tmp_path, large_payload):
-    """Return a remote path that is a file larger than 64k B, which is the most libssh can read at once."""
+    """Return a remote path that to a 65537 byte-sized file.
+
+    Typical single-read chunk size is 64kB in ``libssh`` so
+    the test needs a file that would overflow that to trigger
+    the read loop.
+    """
     path = tmp_path / 'large.txt'
     path.write_bytes(large_payload)
     return path

--- a/tests/unit/scp_test.py
+++ b/tests/unit/scp_test.py
@@ -4,6 +4,7 @@
 
 import os
 import random
+import string
 import uuid
 
 import pytest
@@ -94,16 +95,12 @@ def test_get_existing_local(pre_existing_file_path, src_path, ssh_scp, transmit_
 
 @pytest.fixture
 def large_payload():
-    """Generate a large test payload."""
-    # buffer of random 1024 bytes -- just printable ones for easier debugging
-    rands = []
-    for _ in range(1024):
-        rnd = chr(random.randint(ord(' '), ord('~')))
-        rands.append(rnd)
-    rand = ''.join(rands)
-    # .. repeated 65 times
-    repeat = 65
-    return ''.join(rand for _ in range(repeat)).encode()
+    """Generate a large 65537 byte (64kB+1B) test payload."""
+    random_char_kilobyte = [ord(random.choice(string.printable)) for _ in range(1024)]
+    full_bytes_number = 64
+    a_64kB_chunk = bytes(random_char_kilobyte * full_bytes_number)
+    the_last_byte = random.choice(random_char_kilobyte).to_bytes(length=1, byteorder='big')
+    return a_64kB_chunk + the_last_byte
 
 
 @pytest.fixture


### PR DESCRIPTION
##### SUMMARY
The current SCP code does not handle large reads. Instead just allocates the large buffer fills up to 64k bytes and then writes the whole to the file (most likely the rest filled with junk).

The libssh returns the number of read bytes from `ssh_scp_read()`  and for practical reasons does not allocate the whole file in memory. The reads are capped to 64k B.

This PR fixes the read by both not allocating the entire file size in memory and reading it by chunks (that much max libssh chunk atm) and writing that to the local file.

##### ISSUE TYPE
- Bugfix Pull Request

##### ADDITIONAL INFORMATION

The attached test case is failing without the change, with errors like this:
```console
_______________________________________________________________________ test_get_large _______________________________________________________________________
[gw0] linux -- Python 3.12.3 /home/jjelen/devel/pylibssh/.tox/python/bin/python

dst_path = PosixPath('/tmp/pytest-of-jjelen/pytest-35/popen-gw0/test_get_large0/dst-file.txt')
src_path_large = PosixPath('/tmp/pytest-of-jjelen/pytest-35/popen-gw0/test_get_large0/large.txt'), ssh_scp = <pylibsshext.scp.SCP object at 0x7f3f83cffac0>
large_payload = b'&PE~~,!=1@F7RaUccg#)q-ru^~f8Zv/-{~tFE-\\>v2_b}i@`N/]_%*~{oD`"F`*4Ns]HK^lewILvC1O[]gFC9(27%MuX$s&24et<dRJ$"& zf_XIqm7...**<J_;?uI47vm\'/A"xi5a!kQXoL=M}ne;$E[B=EpasVbRO&\\zy7t,GK yu;l*$s<#P:sJLi@od#:&:m?8]9KFN4@QAF8hD, ~T@WNP;)%+>)TV\'ODi9'

    def test_get_large(dst_path, src_path_large, ssh_scp, large_payload):
        """Check that SCP file download works also for large files."""
>       ssh_scp.get(str(src_path_large), str(dst_path))

dst_path   = PosixPath('/tmp/pytest-of-jjelen/pytest-35/popen-gw0/test_get_large0/dst-file.txt')
large_payload = (b'&PE~~,!=1@F7RaUccg#)q-ru^~f8Zv/-{~tFE-\\>v2_b}i@`N/]_%*~{oD`"F`*4Ns]HK^le'
[...]
 b"?8]9KFN4@QAF8hD, ~T@WNP;)%+>)TV'ODi9")
src_path_large = PosixPath('/tmp/pytest-of-jjelen/pytest-35/popen-gw0/test_get_large0/large.txt')
ssh_scp    = <pylibsshext.scp.SCP object at 0x7f3f83cffac0>


tests/unit/scp_test.py:111: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   raise LibsshSCPException("Unexpected request: %s" % self._get_ssh_error_str())
E   pylibsshext.errors.LibsshSCPException: Unexpected request: b'ssh_scp_pull_request called under invalid state'


src/pylibsshext/scp.pyx:148: LibsshSCPException
```
(lines do not match)

Additionally, there is one more test case, that I suspected will be problematic, but it turned out it works just ok, so leaving for the coverage.