### PR TITLE
Implement asynchronous SFTP file transfer

### DIFF
--- a/docs/changelog-fragments/641.feature.rst
+++ b/docs/changelog-fragments/641.feature.rst
@@ -1,0 +1,1 @@
+Added support for asynchronous SFTP file transfers to increase throughput -- by :user:`Jakuje`.

--- a/src/pylibsshext/includes/sftp.pxd
+++ b/src/pylibsshext/includes/sftp.pxd
@@ -22,7 +22,10 @@ from libc cimport stdint
 from pylibsshext.includes.libssh cimport ssh_channel, ssh_session, ssh_string
 
 
-cdef extern from "libssh/sftp.h" nogil:
+cdef extern from "includes/sftp_compat.h" nogil:
+
+    enum:
+        HAVE_SFTP_AIO
 
     struct sftp_session_struct:
         pass
@@ -84,6 +87,25 @@ cdef extern from "libssh/sftp.h" nogil:
 
     sftp_attributes sftp_stat(sftp_session session, const char *path)
 
+    void sftp_attributes_free(sftp_attributes file)
+
+    struct sftp_aio_struct:
+        pass
+    ctypedef sftp_aio_struct * sftp_aio
+    ssize_t sftp_aio_begin_read(sftp_file file, size_t len, sftp_aio *aio)
+    ssize_t sftp_aio_wait_read(sftp_aio *aio, void *buf, size_t buf_size)
+    ssize_t sftp_aio_begin_write(sftp_file file, const void *buf, size_t len, sftp_aio *aio)
+    ssize_t sftp_aio_wait_write(sftp_aio *aio)
+    void sftp_aio_free(sftp_aio aio)
+
+    struct sftp_limits_struct:
+        stdint.uint64_t max_packet_length
+        stdint.uint64_t max_read_length
+        stdint.uint64_t max_write_length
+        stdint.uint64_t max_open_handles
+    ctypedef sftp_limits_struct * sftp_limits_t
+    sftp_limits_t sftp_limits(sftp_session sftp)
+    void sftp_limits_free(sftp_limits_t limits)
 
 cdef extern from "sys/stat.h" nogil:
     cdef int S_IRWXU

--- a/src/pylibsshext/includes/sftp_compat.h
+++ b/src/pylibsshext/includes/sftp_compat.h
@@ -1,0 +1,72 @@
+#pragma once
+#include <stdint.h>
+#include <libssh/libssh.h>
+#include <libssh/sftp.h>
+
+#if LIBSSH_VERSION_INT >= SSH_VERSION_INT(0, 11, 0)
+
+#define HAVE_SFTP_AIO 1
+
+#else
+
+#define HAVE_SFTP_AIO 0
+
+/*
+ * 1. STUB THE TYPES
+ * Cython just needs to know these are pointer-sized.
+ * Mapping them to void* keeps the C compiler perfectly happy.
+ */
+struct sftp_limits_struct {
+    uint64_t max_packet_length;   /** maximum number of bytes in a single sftp packet */
+    uint64_t max_read_length;     /** maximum length in a SSH_FXP_READ packet */
+    uint64_t max_write_length;    /** maximum length in a SSH_FXP_WRITE packet */
+    uint64_t max_open_handles;    /** maximum number of active handles allowed by server */
+};
+typedef struct sftp_limits_struct* sftp_limits_t;
+
+struct sftp_aio_struct {
+    int _unused;
+};
+typedef struct sftp_aio_struct* sftp_aio;
+
+/*
+ * 2. STUB THE LIMITS FUNCTIONS
+ * (Cast arguments to void to suppress unused variable warnings)
+ */
+static inline sftp_limits_t sftp_limits(sftp_session sftp) {
+    (void)sftp;
+    return NULL;
+}
+
+static inline void sftp_limits_free(sftp_limits_t limits) {
+    (void)limits;
+}
+
+/*
+ * 3. STUB THE AIO FUNCTIONS
+ */
+static inline ssize_t sftp_aio_begin_read(sftp_file file, size_t len, sftp_aio *aio) {
+    (void)file; (void)len; (void)aio;
+    return SSH_ERROR;
+}
+
+static inline ssize_t sftp_aio_wait_read(sftp_aio *aio, void *buf, size_t buf_size) {
+    (void)aio; (void)buf; (void)buf_size;
+    return SSH_ERROR;
+}
+
+static inline ssize_t sftp_aio_begin_write(sftp_file file, const void *buf, size_t len, sftp_aio *aio) {
+    (void)file; (void)buf; (void)len; (void)aio;
+    return SSH_ERROR;
+}
+
+static inline ssize_t sftp_aio_wait_write(sftp_aio *aio) {
+    (void)aio;
+    return SSH_ERROR;
+}
+
+static inline void sftp_aio_free(sftp_aio aio) {
+    (void)aio;
+}
+
+#endif

--- a/src/pylibsshext/sftp.pxd
+++ b/src/pylibsshext/sftp.pxd
@@ -16,6 +16,8 @@
 # License along with this library; if not, see file LICENSE.rst in this
 # repository.
 #
+from libc cimport stdint
+
 from pylibsshext.includes cimport libssh, sftp
 from pylibsshext.session cimport Session
 
@@ -23,3 +25,19 @@ from pylibsshext.session cimport Session
 cdef class SFTP:
     cdef Session session
     cdef sftp.sftp_session _libssh_sftp_session
+
+cdef class _RemoteFile:
+    cdef sftp.sftp_file _fd
+
+cdef class SFTP_AIO:
+    cdef SFTP _sftp_obj
+    cdef _aio_queue
+    cdef _remote_file
+    cdef _local_file
+    cdef stdint.uint64_t _file_size
+    cdef stdint.uint64_t _total_bytes_requested
+    cdef sftp.sftp_session _sftp
+    cdef sftp.sftp_limits_t _limits
+
+cdef class C_AIO:
+    cdef sftp.sftp_aio aio

--- a/src/pylibsshext/sftp.pyx
+++ b/src/pylibsshext/sftp.pyx
@@ -15,6 +15,10 @@
 # License along with this library; if not, see file LICENSE.rst in this
 # repository.
 
+import os
+from collections import deque
+from typing import BinaryIO
+
 from posix.fcntl cimport O_CREAT, O_RDONLY, O_TRUNC, O_WRONLY
 
 from cpython.mem cimport PyMem_Free, PyMem_Malloc
@@ -27,6 +31,13 @@ from pylibsshext.session cimport get_libssh_session
 # The value 32kB is a safe fallback when we cannot determine better value from
 # the server, for example using limits@openssh.com (since libssh 0.11.0).
 SFTP_MAX_CHUNK = 32_768
+
+# 255kB is absolute maximum we want to send over the SSH channel. Sending
+# more will likely not work and capping at some value will prevent DoS.
+SFTP_MAX_CHUNK_LIMIT = 261_120
+
+# Default number of requests for asynchronous/overlapping uploads and downloads.
+SFTP_MAX_REQUESTS = 10
 
 
 MSG_MAP = {
@@ -45,6 +56,40 @@ MSG_MAP = {
     sftp.SSH_FX_WRITE_PROTECT: "We are trying to write on a write-protected filesystem",
     sftp.SSH_FX_NO_MEDIA: "No media in remote drive"
 }
+
+cdef class _RemoteFile:
+    """Helper class managing lifetime of remote file handle."""
+    def __cinit__(self, sftp_obj: SFTP, path: str | bytes, int flags):
+        mode = "write" if flags & O_WRONLY else "read"
+        path_b = path
+        if isinstance(path_b, str):
+            path_b = path.encode("utf-8")
+
+        self._fd = sftp.sftp_open(
+            sftp_obj._libssh_sftp_session,
+            path_b,
+            flags,
+            sftp.S_IRWXU)
+        if self._fd is NULL:
+            raise LibsshSFTPException(
+                "Opening remote file [%s] for %s failed with error [%s]"
+                % (str(path), mode, sftp_obj._get_sftp_error_str()))
+
+    def __dealloc__(self):
+        if self._fd is not NULL:
+            sftp.sftp_close(self._fd)
+            self._fd = NULL
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self._fd is not NULL:
+            sftp.sftp_close(self._fd)
+            self._fd = NULL
+        return False
+
+
 cdef class SFTP:
     def __cinit__(self, session):
         self.session = session
@@ -59,16 +104,18 @@ cdef class SFTP:
             sftp.sftp_free(self._libssh_sftp_session)
             self._libssh_sftp_session = NULL
 
-    def put(self, local_file, remote_file):
+    def put(self, local_file: str | os.PathLike, remote_file: str | bytes):
         """
         Upload local file to remote server.
 
         :param local_file: The file name on the local file system to upload
-        :type local_file: str or os.PathLike
 
         :param remote_file: The path to upload the file on the remote system
-        :type remote_file: str or bytes
         """
+        if sftp.HAVE_SFTP_AIO:
+            return SFTP_AIO(self).put(local_file, remote_file)
+
+        # Synchronous code compatible with libssh < 0.11.0
         cdef sftp.sftp_file rf
         cdef const char* c_buf
         with open(local_file, "rb") as f:
@@ -108,7 +155,7 @@ cdef class SFTP:
                 read_buffer = f.read(SFTP_MAX_CHUNK)
             sftp.sftp_close(rf)
 
-    def get(self, remote_file, local_file):
+    def get(self, remote_file: str | bytes, local_file: str | os.PathLike):
         """
         Download remote file to local path.
 
@@ -118,12 +165,15 @@ cdef class SFTP:
         :param local_file: The path on the local file system to place the downloaded file
         :type local_file: str or os.PathLike
         """
-        cdef sftp.sftp_file rf
+        if sftp.HAVE_SFTP_AIO:
+            return SFTP_AIO(self).get(remote_file, local_file)
+
+        # Synchronous code compatible with libssh < 0.11.0
         cdef char *read_buffer = NULL
         cdef sftp.sftp_attributes attrs
 
         remote_file_b = remote_file
-        if isinstance(remote_file_b, unicode):
+        if isinstance(remote_file_b, str):
             remote_file_b = remote_file.encode("utf-8")
 
         attrs = sftp.sftp_stat(self._libssh_sftp_session, remote_file_b)
@@ -198,3 +248,254 @@ cdef class SFTP:
         if error in MSG_MAP and error != sftp.SSH_FX_FAILURE:
             return MSG_MAP[error]
         return "Generic failure: %s" % self.session._get_session_error_str()
+
+
+cdef class SFTP_AIO:
+    def __cinit__(self, SFTP sftp_obj):
+        self._limits = NULL
+        self._sftp_obj = sftp_obj
+        self._sftp = sftp_obj._libssh_sftp_session
+
+        self._limits = sftp.sftp_limits(self._sftp)
+        if self._limits is NULL:
+            raise LibsshSFTPException(
+                "Failed to get remote SFTP limits [%s]"
+                % (
+                    self._sftp_obj._get_sftp_error_str(),
+                ),
+            )
+
+    def __init__(self, SFTP sftp_obj):
+        self._aio_queue = deque()
+
+    def __dealloc__(self):
+        if self._limits is not NULL:
+            sftp.sftp_limits_free(self._limits)
+            self._limits = NULL
+
+    def _get_file_size(self, local_fd: BinaryIO) -> int:
+        local_fd.seek(0, os.SEEK_END)
+        file_size = local_fd.tell()
+        local_fd.seek(0, os.SEEK_SET)
+        return file_size
+
+    def put(self, local_file: str | os.PathLike, remote_file: str | bytes):
+        """
+        Upload a local file to remote server using asynchronous IO (AIO)
+
+        This method sends more write packets before waiting for write
+        confirmation from the server. In combination with larger chunks,
+        this allows faster transfers especially over large latency channels.
+
+        :param local_file: The file name on the local file system to upload
+
+        :param remote_file: The path to upload the file on the remote system
+        """
+        self._aio_queue = deque()
+        self._total_bytes_requested = 0
+
+        cdef C_AIO aio
+        cdef _RemoteFile remote
+        self._remote_file = remote_file
+        self._local_file = local_file
+
+        with _RemoteFile(self._sftp_obj, remote_file, O_WRONLY | O_CREAT | O_TRUNC) as remote:
+            with open(local_file, "rb") as local_fd:
+                self._file_size = self._get_file_size(local_fd)
+
+                # start multiple requests before waiting for responses
+                i = 0
+                while i < SFTP_MAX_REQUESTS and self._total_bytes_requested < self._file_size:
+                    self._put_chunk(local_fd, remote)
+                    i += 1
+
+                while len(self._aio_queue):
+                    aio = self._aio_queue.popleft()
+                    bytes_written = sftp.sftp_aio_wait_write(&aio.aio)
+                    if bytes_written == libssh.SSH_ERROR:
+                        raise LibsshSFTPException(
+                            "Failed to write to remote file [%s]: error [%s]"
+                            % (
+                                remote_file,
+                                self._sftp_obj._get_sftp_error_str(),
+                            ),
+                        )
+                    # was freed in the wait if it did not fail
+                    aio.aio = NULL
+
+                    # whole file written
+                    if self._total_bytes_requested == self._file_size:
+                        continue
+
+                    # else issue more write requests
+                    self._put_chunk(local_fd, remote)
+
+    def _cap_write_size(self, length: int) -> int:
+        """
+        Calculate the number of bytes to write over the channel in one chunk
+
+        Takes the remaining bytes in the file. The output value is capped
+        to the server limits but hard-limited by 255k (SFTP_MAX_CHUNK_LIMIT).
+        The care is also taken to make sure the server does not provide
+        maliciously small value like 0, which would cause DoS.
+        """
+        limit = max(self._limits.max_write_length, SFTP_MAX_CHUNK)
+        limit = min(limit, SFTP_MAX_CHUNK_LIMIT)
+        return min(length, limit)
+
+    def _cap_read_size(self, length: int) -> int:
+        """
+        Calculate the number of bytes to read over the channel in one chunk
+
+        Takes the remaining bytes in the file. The output value is capped
+        to the server limits but hard-limited by 255k (SFTP_MAX_CHUNK_LIMIT).
+        The care is also taken to make sure the server does not provide
+        maliciously small value like 0, which would cause DoS.
+        """
+        limit = max(self._limits.max_read_length, SFTP_MAX_CHUNK)
+        limit = min(limit, SFTP_MAX_CHUNK_LIMIT)
+        return min(length, limit)
+
+    def _put_chunk(self, local_fd: BinaryIO, remote: _RemoteFile):
+        to_write = self._cap_write_size(self._file_size - self._total_bytes_requested)
+        read_buffer = local_fd.read(to_write)
+        if len(read_buffer) != to_write:
+            raise LibsshSFTPException(
+                "Read only [%d] but requested [%d] when reading from local file [%s]"
+                % (
+                    len(read_buffer),
+                    to_write,
+                    self._local_file,
+                ),
+            )
+
+        cdef sftp.sftp_aio aio = NULL
+        cdef const char* c_buf = read_buffer
+        bytes_requested = sftp.sftp_aio_begin_write(remote._fd, c_buf, to_write, &aio)
+        if bytes_requested != to_write:
+            raise LibsshSFTPException(
+                "Failed to write chunk of size [%d] of file [%s] with error [%s]"
+                % (
+                    to_write,
+                    self._remote_file,
+                    self._sftp_obj._get_sftp_error_str(),
+                ),
+            )
+        self._total_bytes_requested += bytes_requested
+        c_aio = C_AIO()
+        c_aio.aio = aio
+        self._aio_queue.append(c_aio)
+
+    def get(self, remote_file: str | bytes, local_file: str or os.PathLike):
+        """
+        Download a remote file to local path using asynchronous IO (AIO)
+
+        This method sends more read request packets before waiting for response
+        data from the server. In combination with larger chunks, this allows
+        faster transfers especially over large latency channels.
+        """
+        self._aio_queue = deque()
+        self._total_bytes_requested = 0
+
+        cdef C_AIO aio
+        cdef _RemoteFile remote
+        cdef sftp.sftp_attributes attrs
+        cdef char *read_buffer = NULL
+        self._remote_file = remote_file
+
+        remote_file_b = remote_file
+        if isinstance(remote_file_b, str):
+            remote_file_b = remote_file.encode("utf-8")
+
+        attrs = sftp.sftp_stat(self._sftp, remote_file_b)
+        if attrs is NULL:
+            raise LibsshSFTPException(
+                "Failed to stat the remote file [%s] with error [%s]"
+                % (
+                    remote_file,
+                    self._sftp_obj._get_sftp_error_str(),
+                ),
+            )
+        self._file_size = attrs.size
+        sftp.sftp_attributes_free(attrs)
+
+        buffer_size = self._cap_read_size(self._file_size)
+        try:
+            read_buffer = <char *>PyMem_Malloc(buffer_size)
+            if buffer_size and read_buffer is NULL:
+                raise LibsshSFTPException("Memory allocation error")
+
+            with _RemoteFile(self._sftp_obj, remote_file, O_RDONLY) as remote:
+                with open(local_file, 'wb') as lccal_fd:
+                    # start multiple read requests before waiting for responses
+                    i = 0
+                    while i < SFTP_MAX_REQUESTS and self._total_bytes_requested < self._file_size:
+                        self._get_chunk(remote)
+                        i += 1
+
+                    while len(self._aio_queue):
+                        aio = self._aio_queue.popleft()
+                        bytes_read = sftp.sftp_aio_wait_read(&aio.aio, <void *>read_buffer, buffer_size)
+                        if bytes_read == libssh.SSH_ERROR:
+                            raise LibsshSFTPException(
+                                "Failed to read from remote file [%s]: error [%s]"
+                                % (
+                                    remote_file,
+                                    self._sftp_obj._get_sftp_error_str(),
+                                ),
+                            )
+                        # was freed in the wait if it did not fail -- otherwise the __dealloc__ will free it
+                        aio.aio = NULL
+
+                        # write the local file
+                        bytes_written = lccal_fd.write(read_buffer[:bytes_read])
+                        if bytes_written != bytes_read:
+                            raise LibsshSFTPException(
+                                "Number of bytes [%d] read from remote file [%s]"
+                                " does not match number of bytes [%d] written to"
+                                " local file [%s]"
+                                % (
+                                    bytes_read,
+                                    remote_file,
+                                    bytes_written,
+                                    local_file,
+                                ),
+                            )
+
+                        # whole file read
+                        if self._total_bytes_requested == self._file_size:
+                            continue
+
+                        # else issue more read requests
+                        self._get_chunk(remote)
+
+        finally:
+            if read_buffer is not NULL:
+                PyMem_Free(read_buffer)
+
+    def _get_chunk(self, remote: _RemoteFile):
+        to_read = self._cap_read_size(self._file_size - self._total_bytes_requested)
+        cdef sftp.sftp_aio aio = NULL
+        bytes_requested = sftp.sftp_aio_begin_read(remote._fd, to_read, &aio)
+        if bytes_requested != to_read:
+            raise LibsshSFTPException(
+                "Failed to request to read chunk of size [%d] of file [%s] with error [%s]"
+                % (
+                    to_read,
+                    self._remote_file,
+                    self._sftp_obj._get_sftp_error_str(),
+                ),
+            )
+        self._total_bytes_requested += bytes_requested
+        c_aio = C_AIO()
+        c_aio.aio = aio
+        self._aio_queue.append(c_aio)
+
+
+cdef class C_AIO:
+    def __cinit__(self):
+        self.aio = NULL
+
+    def __dealloc__(self):
+        sftp.sftp_aio_free(self.aio)
+        self.aio = NULL

--- a/tests/unit/sftp_test.py
+++ b/tests/unit/sftp_test.py
@@ -5,7 +5,7 @@ import uuid
 
 import pytest
 
-from pylibsshext.sftp import SFTP_MAX_CHUNK
+from pylibsshext.sftp import SFTP_MAX_CHUNK, SFTP_MAX_CHUNK_LIMIT
 
 
 SMALL_PAYLOAD = 32
@@ -37,6 +37,12 @@ def sftp_session(ssh_client_session):
             # at least two rounds of reading/writing
             SFTP_MAX_CHUNK + 1,
             id='large-payload',
+        ),
+        pytest.param(
+            # 1B larger than any limits advertised by SFTP servers
+            # passing this directly on wire will not be handled by server
+            SFTP_MAX_CHUNK_LIMIT + 1,
+            id='huge-payload',
         ),
     ),
 )


### PR DESCRIPTION
##### SUMMARY
The SFTP transfers done the way they work now are very slow especially on connections with large latency because each chunk (now 1024B) needs to travel all the way to remote as well as the confirmation (or request + data for the other transfer), before another chunk is sent. This can be improved by two things: 
 * sending larger chunks (up to the size reported by SFTP limits extension)
 * sending more requests while waiting for the confirmation/data

This depends on #636 (libssh 0.11), but also on other platforms having the updated libssh. It will likely need some conditional compilation based on the libssh version, but I did not find a good solution for cython after it was deprecated (cython/cython#4310) so any help/suggestions welcomed.

This PR also reproduces an issue with the new API that it currently hangs waiting for the second message, while it already happily sits in the queue, which is being worked on upstream.

Therefore marking as a draft to collect initial inputs.

##### ISSUE TYPE
- Feature Pull Request