### PR TITLE
Fix `scp.put()` args order in the documentation snippet

### DIFF
--- a/docs/_samples/copy_files_scp.py
+++ b/docs/_samples/copy_files_scp.py
@@ -29,6 +29,6 @@ if ssh.is_connected:
     scp.get(remote_file, local_file)
 
     scp = ssh.scp()
-    scp.put(remote_file, local_file)
+    scp.put(local_file, remote_file)
 
 ssh.close()

--- a/docs/changelog-fragments/646.doc.rst
+++ b/docs/changelog-fragments/646.doc.rst
@@ -1,1 +1,2 @@
-Fix scp.put() usage in documentation sample -- by :user:`kucharskim`.
+Fixed the argument order in the ``scp.put()`` usage example
+-- by :user:`kucharskim`.

--- a/docs/changelog-fragments/646.doc.rst
+++ b/docs/changelog-fragments/646.doc.rst
@@ -1,0 +1,1 @@
+Fix scp.put() usage in documentation sample -- by :user:`kucharskim`.


### PR DESCRIPTION
Related to https://github.com/ansible/pylibssh/issues/646

Preview: https://ansible-pylibssh--659.org.readthedocs.build/en/659/user_guide/#copy-file-to-remote-host / https://ansible-pylibssh--659.org.readthedocs.build/en/659/changelog/#improved-documentation