### PR TITLE
Add support for requesting a subsystem on a channel

### DIFF
--- a/docs/changelog-fragments/669.feature.rst
+++ b/docs/changelog-fragments/669.feature.rst
@@ -1,0 +1,1 @@
+Support requesting for a subsystem on a channel -- by :user:`NilashishC`

--- a/src/pylibsshext/channel.pyx
+++ b/src/pylibsshext/channel.pyx
@@ -92,6 +92,11 @@ cdef class Channel:
         if rc != libssh.SSH_OK:
             raise LibsshChannelException("Failed to request_shell: [%d]" % rc)
 
+    def request_subsystem(self, subsystem):
+        rc = libssh.ssh_channel_request_subsystem(self._libssh_channel, subsystem.encode("utf-8"))
+        if rc != libssh.SSH_OK:
+            raise LibsshChannelException("Failed to request subsystem: [%d]" % rc)
+
     def poll(self, timeout=-1, stderr=0):
         if timeout < 0:
             rc = libssh.ssh_channel_poll(self._libssh_channel, stderr)

--- a/src/pylibsshext/channel.pyx
+++ b/src/pylibsshext/channel.pyx
@@ -95,7 +95,7 @@ cdef class Channel:
     def request_subsystem(self, subsystem):
         rc = libssh.ssh_channel_request_subsystem(self._libssh_channel, subsystem.encode("utf-8"))
         if rc != libssh.SSH_OK:
-            raise LibsshChannelException("Failed to request subsystem: [%d]" % rc)
+            raise LibsshChannelException("Failed to request subsystem %s: [%d]" % (subsystem, rc))
 
     def poll(self, timeout=-1, stderr=0):
         if timeout < 0:

--- a/src/pylibsshext/includes/libssh.pxd
+++ b/src/pylibsshext/includes/libssh.pxd
@@ -202,7 +202,7 @@ cdef extern from "libssh/libssh.h" nogil:
     int ssh_channel_open_session(ssh_channel channel)
     int ssh_channel_request_pty(ssh_channel channel)
     int ssh_channel_request_pty_size(ssh_channel channel, const char *term, int cols, int rows)
-    int ssh_channel_request_subsystem   (ssh_channel channel, const char *subsys )
+    int ssh_channel_request_subsystem(ssh_channel channel, const char *subsys)
     int ssh_channel_request_shell(ssh_channel channel)
     int ssh_channel_is_open(ssh_channel channel)
     int ssh_channel_write(ssh_channel channel, const void *data, uint32_t len)

--- a/src/pylibsshext/includes/libssh.pxd
+++ b/src/pylibsshext/includes/libssh.pxd
@@ -202,6 +202,7 @@ cdef extern from "libssh/libssh.h" nogil:
     int ssh_channel_open_session(ssh_channel channel)
     int ssh_channel_request_pty(ssh_channel channel)
     int ssh_channel_request_pty_size(ssh_channel channel, const char *term, int cols, int rows)
+    int ssh_channel_request_subsystem	(ssh_channel channel, const char *subsys )
     int ssh_channel_request_shell(ssh_channel channel)
     int ssh_channel_is_open(ssh_channel channel)
     int ssh_channel_write(ssh_channel channel, const void *data, uint32_t len)

--- a/src/pylibsshext/includes/libssh.pxd
+++ b/src/pylibsshext/includes/libssh.pxd
@@ -202,7 +202,7 @@ cdef extern from "libssh/libssh.h" nogil:
     int ssh_channel_open_session(ssh_channel channel)
     int ssh_channel_request_pty(ssh_channel channel)
     int ssh_channel_request_pty_size(ssh_channel channel, const char *term, int cols, int rows)
-    int ssh_channel_request_subsystem	(ssh_channel channel, const char *subsys )
+    int ssh_channel_request_subsystem   (ssh_channel channel, const char *subsys )
     int ssh_channel_request_shell(ssh_channel channel)
     int ssh_channel_is_open(ssh_channel channel)
     int ssh_channel_write(ssh_channel channel, const void *data, uint32_t len)

--- a/src/pylibsshext/session.pyx
+++ b/src/pylibsshext/session.pyx
@@ -513,6 +513,11 @@ cdef class Session(object):
     def invoke_shell(self):
         return self.new_shell_channel()
 
+    def invoke_subsystem(self, subsystem):
+        channel = self.new_channel()
+        channel.request_subsystem(subsystem)
+        return channel
+
     def scp(self):
         return SCP(self)
 


### PR DESCRIPTION
##### SUMMARY
Allow users to request a subsystem (such as `netconf`) on the channel.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

