### PR TITLE
🧪 Bump `actions/{upload,download}-artifact` to v4

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1124,7 +1124,7 @@ jobs:
       run: mkdir -pv ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 
     - name: Retrieve the project source from an sdist inside the GHA artifact
-      uses: re-actors/checkout-python-sdist@release/v1
+      uses: re-actors/checkout-python-sdist@release/v2
       with:
         source-tarball-name: ${{ needs.pre-setup.outputs.sdist-artifact-name }}
         workflow-artifact-name: >-
@@ -1404,7 +1404,7 @@ jobs:
         python-version: 3.11
 
     - name: Retrieve the project source from an sdist inside the GHA artifact
-      uses: re-actors/checkout-python-sdist@release/v1
+      uses: re-actors/checkout-python-sdist@release/v2
       with:
         source-tarball-name: ${{ needs.pre-setup.outputs.sdist-artifact-name }}
         workflow-artifact-name: >-

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -597,7 +597,7 @@ jobs:
     - name: Verify that expected patch got created
       run: ls -1 '${{ needs.pre-setup.outputs.changelog-patch-name }}'
     - name: Save the package bump patch as a GHA artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: changelog
         path: |
@@ -876,7 +876,7 @@ jobs:
         ref: ${{ github.event.inputs.release-committish }}
 
     - name: Fetch the GHA artifact with the version patch
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: changelog
     - name: Apply the changelog patch but do not commit it
@@ -1017,7 +1017,7 @@ jobs:
         'dist/${{ needs.pre-setup.outputs.sdist-artifact-name }}'
     - name: Store the source distribution package
       if: fromJSON(matrix.store-sdist-to-artifact)
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ needs.pre-setup.outputs.dists-artifact-name }}
         # NOTE: Exact expected file names are specified here
@@ -1137,10 +1137,11 @@ jobs:
         packaging/rpm/ansible-pylibssh.spec
 
     - name: Download all the dists  # because `rpmlint` executes the spec file
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
-        name: ${{ needs.pre-setup.outputs.dists-artifact-name }}
+        pattern: ${{ needs.pre-setup.outputs.dists-artifact-name }}*
         path: dist/
+        merge-multiple: true
 
     - name: Lint the RPM spec file
       if: >-
@@ -1303,7 +1304,7 @@ jobs:
         );
         echo "artifact-id=${normalized_container_id}" >> "${GITHUB_OUTPUT}"
     - name: Store RPM and SRPM as artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ steps.artifact-name.outputs.artifact-id }}--srpm-n-rpm
         path: |
@@ -1456,10 +1457,11 @@ jobs:
     - name: Pre-populate tox env
       run: python -m tox -p auto --parallel-live -vvvv --notest
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
-        name: ${{ needs.pre-setup.outputs.dists-artifact-name }}
+        pattern: ${{ needs.pre-setup.outputs.dists-artifact-name }}*
         path: dist/
+        merge-multiple: true
     - name: Verify metadata
       run: python -m tox -p auto --parallel-live -vvvv
 
@@ -1516,11 +1518,12 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
-        name: >-
-          ${{ needs.pre-setup.outputs.dists-artifact-name }}
+        pattern: >-
+          ${{ needs.pre-setup.outputs.dists-artifact-name }}*
         path: dist/
+        merge-multiple: true
     - name: >-
         📦
         Publish ${{ needs.pre-setup.outputs.git-tag }} to PyPI
@@ -1560,11 +1563,12 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
-        name: >-
-          ${{ needs.pre-setup.outputs.dists-artifact-name }}
+        pattern: >-
+          ${{ needs.pre-setup.outputs.dists-artifact-name }}*
         path: dist/
+        merge-multiple: true
     - name: >-
         📦
         Publish ${{ needs.pre-setup.outputs.git-tag }} to TestPyPI
@@ -1647,7 +1651,7 @@ jobs:
       uses: fregante/setup-git-user@v2
     - name: Fetch the GHA artifact with the version patch
       if: steps.existing-remote-tag-check.outputs.already-exists != 'true'
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: changelog
 
@@ -1749,12 +1753,13 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
-        name: ${{ needs.pre-setup.outputs.dists-artifact-name }}
+        pattern: ${{ needs.pre-setup.outputs.dists-artifact-name }}*
         path: dist/
+        merge-multiple: true
     - name: Fetch the GHA artifact with the version patch
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: changelog
 
@@ -1893,10 +1898,11 @@ jobs:
         --pre
         ansible-pylibssh
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
-        name: ${{ needs.pre-setup.outputs.dists-artifact-name }}
+        pattern: ${{ needs.pre-setup.outputs.dists-artifact-name }}*
         path: dist/
+        merge-multiple: true
 
     - name: Switch to Python 3.11
       uses: actions/setup-python@v5.3.0

--- a/.github/workflows/reusable-build-wheel.yml
+++ b/.github/workflows/reusable-build-wheel.yml
@@ -117,7 +117,7 @@ jobs:
         python-version: 3.11
 
     - name: Retrieve the project source from an sdist inside the GHA artifact
-      uses: re-actors/checkout-python-sdist@release/v1
+      uses: re-actors/checkout-python-sdist@release/v2
       with:
         source-tarball-name: ${{ inputs.source-tarball-name }}
         workflow-artifact-name: ${{ inputs.dists-artifact-name }}

--- a/.github/workflows/reusable-build-wheel.yml
+++ b/.github/workflows/reusable-build-wheel.yml
@@ -92,6 +92,25 @@ jobs:
         }}-${{ inputs.manylinux-image-target-arch }},metadata-validation
 
     steps:
+    - name: Compute GHA artifact name ending
+      id: gha-artifact-name
+      run: |
+        from hashlib import sha512
+        from os import environ
+        from pathlib import Path
+
+        FILE_APPEND_MODE = 'a'
+
+        inputs_json_str = """${{ toJSON(inputs) }}"""
+
+        hash = sha512(inputs_json_str.encode()).hexdigest()
+
+        with Path(environ['GITHUB_OUTPUT']).open(
+                mode=FILE_APPEND_MODE,
+        ) as outputs_file:
+            print(f'hash={hash}', file=outputs_file)
+      shell: python
+
     - name: Switch to using Python 3.11 by default
       uses: actions/setup-python@v5.3.0
       with:
@@ -184,9 +203,14 @@ jobs:
         ls -1
         dist/${{ inputs.wheel-artifact-name }}
     - name: Store ${{ inputs.manylinux-python-target }} binary wheel
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: ${{ inputs.dists-artifact-name }}
+        name: ${{ inputs.dists-artifact-name }}-
+          ${{ inputs.manylinux-year-target }}-
+          ${{ inputs.manylinux-image-target-arch }}-
+          ${{ inputs.manylinux-image-target-qemu-arch }}-
+          ${{ inputs.manylinux-python-target }}-
+          ${{ steps.gha-artifact-name.outputs.hash }}
         # NOTE: Exact expected file names are specified here
         # NOTE: as a safety measure — if anything weird ends
         # NOTE: up being in this dir or not all dists will be

--- a/.github/workflows/reusable-cibuildwheel.yml
+++ b/.github/workflows/reusable-cibuildwheel.yml
@@ -66,7 +66,7 @@ jobs:
       shell: python
 
     - name: Retrieve the project source from an sdist inside the GHA artifact
-      uses: re-actors/checkout-python-sdist@release/v1
+      uses: re-actors/checkout-python-sdist@release/v2
       with:
         source-tarball-name: ${{ inputs.source-tarball-name }}
         workflow-artifact-name: ${{ inputs.dists-artifact-name }}

--- a/.github/workflows/reusable-cibuildwheel.yml
+++ b/.github/workflows/reusable-cibuildwheel.yml
@@ -46,6 +46,25 @@ jobs:
     runs-on: ${{ inputs.os }}
     timeout-minutes: ${{ inputs.qemu && 60 || 20 }}
     steps:
+    - name: Compute GHA artifact name ending
+      id: gha-artifact-name
+      run: |
+        from hashlib import sha512
+        from os import environ
+        from pathlib import Path
+
+        FILE_APPEND_MODE = 'a'
+
+        inputs_json_str = """${{ toJSON(inputs) }}"""
+
+        hash = sha512(inputs_json_str.encode()).hexdigest()
+
+        with Path(environ['GITHUB_OUTPUT']).open(
+                mode=FILE_APPEND_MODE,
+        ) as outputs_file:
+            print(f'hash={hash}', file=outputs_file)
+      shell: python
+
     - name: Retrieve the project source from an sdist inside the GHA artifact
       uses: re-actors/checkout-python-sdist@release/v1
       with:
@@ -81,9 +100,12 @@ jobs:
           with-cython-tracing=${{ inputs.cython-tracing }}
 
     - name: Upload built artifacts for testing and publishing
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: ${{ inputs.dists-artifact-name }}
+        name: ${{ inputs.dists-artifact-name }}-
+          ${{ inputs.os }}-
+          ${{ inputs.qemu }}-
+          ${{ steps.gha-artifact-name.outputs.hash }}
         path: ./wheelhouse/*.whl
 
 ...

--- a/.github/workflows/reusable-tests.yml
+++ b/.github/workflows/reusable-tests.yml
@@ -108,7 +108,7 @@ jobs:
         python-version: ${{ inputs.python-version }}
 
     - name: Retrieve the project source from an sdist inside the GHA artifact
-      uses: re-actors/checkout-python-sdist@release/v1
+      uses: re-actors/checkout-python-sdist@release/v2
       with:
         source-tarball-name: ${{ inputs.source-tarball-name }}
         workflow-artifact-name: ${{ inputs.dists-artifact-name }}

--- a/.github/workflows/reusable-tests.yml
+++ b/.github/workflows/reusable-tests.yml
@@ -190,10 +190,11 @@ jobs:
         '${{ env.TOX_VERSION }}'
 
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
-        name: ${{ inputs.dists-artifact-name }}
+        pattern: ${{ needs.pre-setup.outputs.dists-artifact-name }}*
         path: dist/
+        merge-multiple: true
 
     - name: >-
         Pre-populate tox env:

--- a/docs/changelog-fragments/676.contrib.rst
+++ b/docs/changelog-fragments/676.contrib.rst
@@ -1,0 +1,7 @@
+All the uses of ``actions/upload-artifact@v3`` and
+``actions/download-artifact@v3`` have been updated to use
+``v4``. This also includes bumping
+``re-actors/checkout-python-sdist`` to ``release/v2`` as it
+uses ``actions/download-artifact`` internally.
+
+-- by :user:`NilashishC` and :user:`webknjaz`


### PR DESCRIPTION
##### SUMMARY

They are updated across all GitHub Actions CI/CD workflow definitions
in the repository. It is necessary due to Artifacts API v3 having been
deprecated on Jan 30, 2025.

As a part of the change, the uploaded artifact names needed to be made
unique and their download counterparts had to be invoked against a
name pattern, merging multiple artifacts together.

Making the names unique came with challenges that this patch overcame
by appending SHA-256 hashes of reusable workflow inputs to the
artifact names.

This change also bumps `re-actors/checkout-python-sdist` to v2 as it
uses `actions/download-artifact` internally and so we
needed to get the version that uses non-deprecated APIs.

[1]: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request
