### PR TITLE
🧪 Define `upstream_version` parse-time macro

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -70,6 +70,9 @@ notifications:
 patch_generation_ignore_paths: []
 patch_generation_patch_id_digits: 4
 
+parse_time_macros:
+  upstream_version: 666
+
 # sources: []
 
 specfile_path: packaging/rpm/ansible-pylibssh.spec


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
SSIA

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

This fixes a problem when Packit attempts to parse the spec file way
too early. Before the version info is available.

Ref: https://packit.dev/docs/configuration#parse_time_macros