### PR TITLE
🐛📦 Fix the OCI manylinux image platform tag

### DIFF
--- a/.github/workflows/build-manylinux-container-images.yml
+++ b/.github/workflows/build-manylinux-container-images.yml
@@ -92,7 +92,7 @@ jobs:
       id: build-image
       uses: redhat-actions/buildah-build@v2.13
       with:
-        arch: linux/${{ env.QEMU_ARCH }}
+        arch: ${{ env.QEMU_ARCH }}
         image: ${{ env.FULL_IMAGE_NAME }}
         tags: >-
           ${{ github.sha }}

--- a/docs/changelog-fragments/692.contrib.rst
+++ b/docs/changelog-fragments/692.contrib.rst
@@ -1,0 +1,5 @@
+The wheel building workflows have been updated to set the
+OCI image platform identifiers to legal values like
+``linux/arm64``.
+
+-- by :user:`webknjaz`

--- a/docs/changelog-fragments/692.packaging.rst
+++ b/docs/changelog-fragments/692.packaging.rst
@@ -1,0 +1,4 @@
+The wheels are now built in cached container images with a
+correctly set platform identifier.
+
+-- by :user:`webknjaz`


### PR DESCRIPTION
This was caused by a mistake during the initial migration from docker to podman in #181. The original command looked like
`docker buildx build --platform linux/arm64` but the `redhat-actions/buildah-build` action has an input called `arch:` that we started using. And we've prefixed the passed value with `linux/`. It would've been fine if we used the `platform:` input but we didn't. The consequence was that the images we were making were tagged with an additional leading `linux/` prefix in the platform metadata which made it look like `linux/linux/arm64`.

The issue became evident in #648 that attempted to bump the version of `cibuildwheel`. And the container interaction started failing loudly as this tool started using the `--platform` option when working with OCI images in v2.21 [[1]].

[1]: https://github.com/pypa/cibuildwheel/pull/1961

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Maintenance Pull Request
- Packaging Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Here's what the crash looks like:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```console
  e897bff8bb4b: Pull complete
  Digest: sha256:d1a2a5447db38774458dc669abadcff717eaa2f6ee5d9797144c659a3f4ae60d
  Status: Downloaded newer image for ghcr.io/ansible/pylibssh-manylinux_2_28_x86_64:libssh-v0.9.6
  image with reference ghcr.io/ansible/pylibssh-manylinux_2_28_x86_64:libssh-v0.9.6 was found but does not match the specified platform: wanted linux/amd64, actual: linux/linux/amd64
```
