### PR TITLE
🧪 Ensure all GHA jobs have timeouts

### DIFF
--- a/.github/workflows/build-manylinux-container-images.yml
+++ b/.github/workflows/build-manylinux-container-images.yml
@@ -21,6 +21,9 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    timeout-minutes: 120
+
     strategy:
       matrix:
         IMAGE:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -433,6 +433,8 @@ jobs:
     - pre-setup
     runs-on: ubuntu-latest
 
+    timeout-minutes: 2  # network is slow sometimes
+
     env:
       TOXENV: make-changelog
 
@@ -756,6 +758,9 @@ jobs:
     - build-changelog
     - pre-setup  # transitive, for accessing settings
     runs-on: ${{ matrix.runner-vm-os }}
+
+    timeout-minutes: 2
+
     strategy:
       matrix:
         python-version:
@@ -975,6 +980,9 @@ jobs:
           registry: registry.access.redhat.com
 
     runs-on: ubuntu-latest
+
+    timeout-minutes: 5
+
     container:
       # NOTE: GHA has poor support for concat which is why I resorted to
       # NOTE: using this ugly ternary syntax
@@ -1302,6 +1310,8 @@ jobs:
     - pre-setup  # transitive, for accessing settings
     runs-on: ubuntu-latest
 
+    timeout-minutes: 1
+
     env:
       TOXENV: metadata-validation
 
@@ -1385,6 +1395,8 @@ jobs:
     - test-macos
 
     runs-on: Ubuntu-latest
+
+    timeout-minutes: 1
 
     steps:
     - name: Decide whether the needed jobs succeeded or failed
@@ -1497,6 +1509,8 @@ jobs:
       always()
       && needs.publish-pypi.result == 'success'
     runs-on: ubuntu-latest
+
+    timeout-minutes: 1
 
     outputs:
       pull_request_url: ${{ steps.pr.outputs.pull_request_url }}
@@ -1782,6 +1796,8 @@ jobs:
         fromJSON(needs.pre-setup.outputs.release-requested)
       )
     runs-on: ubuntu-latest
+
+    timeout-minutes: 5
 
     environment:
       name: github-pages

--- a/.github/workflows/reusable-linters.yml
+++ b/.github/workflows/reusable-linters.yml
@@ -13,6 +13,9 @@ jobs:
     name: >-
       ${{ matrix.toxenv }}/${{ matrix.python-version }}@${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+
+    timeout-minutes: 2
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/reusable-tests.yml
+++ b/.github/workflows/reusable-tests.yml
@@ -71,6 +71,8 @@ jobs:
       ${{ inputs.dist-type }} dist
     runs-on: ${{ inputs.runner-vm-os }}
 
+    timeout-minutes: 7
+
     continue-on-error: >-
       ${{
           (

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,18 @@ repos:
   hooks:
   - id: remove-tabs
 
+- repo: https://github.com/python-jsonschema/check-jsonschema.git
+  rev: 0.33.0
+  hooks:
+  - id: check-jsonschema
+    name: Check GitHub Workflows set timeout-minutes
+    args:
+    - --builtin-schema
+    - github-workflows-require-timeout
+    files: ^\.github/workflows/[^/]+$
+    types:
+    - yaml
+
 - repo: https://github.com/pre-commit/pygrep-hooks.git
   rev: v1.10.0
   hooks:

--- a/docs/changelog-fragments/706.contrib.rst
+++ b/docs/changelog-fragments/706.contrib.rst
@@ -1,0 +1,6 @@
+The CI is now configured to always set job timeout values.
+This will ensure that the jobs that get stuck don't consume
+all 6 hours just hanging, improving responsiveness and the
+overall CI/CD resource usage.
+
+-- by :user:`webknjaz`


### PR DESCRIPTION
This is the best practice and if unfollowed, it may result in stuck jobs consuming 6 hours each before failing. Setting timeouts close to the typical run times improves responsiveness in case of trouble.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
$sbj. Resolves #557.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Some of the Python 3.12+ jobs get stuck and wait for 6 hours. This prevents that.

Ref: https://github.com/ansible/pylibssh/pull/658#issuecomment-2754499713.