### PR TITLE
🧪 Enable all the jsonschema linters in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,10 @@ repos:
 - repo: https://github.com/python-jsonschema/check-jsonschema.git
   rev: 0.33.0
   hooks:
+  - id: check-github-workflows
+    files: ^\.github/workflows/[^/]+$
+    types:
+    - yaml
   - id: check-jsonschema
     name: Check GitHub Workflows set timeout-minutes
     args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,7 @@ repos:
     files: ^\.github/workflows/[^/]+$
     types:
     - yaml
+  - id: check-readthedocs
 
 - repo: https://github.com/pre-commit/pygrep-hooks.git
   rev: v1.10.0

--- a/docs/changelog-fragments/707.contrib.rst
+++ b/docs/changelog-fragments/707.contrib.rst
@@ -1,0 +1,5 @@
+The linting is now configured to check schemas of the
+Read The Docs configuration file and the GitHub Actions
+CI/CD workflow files in addition to enforcing timeouts.
+
+-- by :user:`webknjaz`


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This patch adds linting of the RTD and GHA configs for known schema compliance.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
N/A