### PR TITLE
🧪 Replace Ubuntu 20.04 with 24.04 in CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1242,8 +1242,8 @@ jobs:
         - 3.9
         - 3.8
         runner-vm-os:
+        - ubuntu-24.04
         - ubuntu-22.04
-        - ubuntu-20.04
         dist-type:
         - binary
         - source

--- a/.github/workflows/reusable-tests.yml
+++ b/.github/workflows/reusable-tests.yml
@@ -98,12 +98,7 @@ jobs:
     - name: Install catchsegv and libssh headers on Linux for cythonize+coverage
       if: >-
         runner.os == 'Linux'
-      run: >-
-        sudo apt update && sudo apt install ${{
-          inputs.runner-vm-os != 'ubuntu-20.04'
-          && 'glibc-tools'
-          || ''
-        }} libssh-dev
+      run: sudo apt update && sudo apt install glibc-tools libssh-dev
     - name: Switch 🐍 to v${{ inputs.python-version }}
       id: python-install
       uses: actions/setup-python@v5.3.0

--- a/docs/changelog-fragments/708.deprecation.rst
+++ b/docs/changelog-fragments/708.deprecation.rst
@@ -1,0 +1,2 @@
+The project stopped being tested under Ubuntu 20.04 VM since
+GitHub has sunset their CI images -- by :user:`webknjaz`.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Ubuntu 20.04 is no longer provided by GitHub.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
https://github.com/actions/runner-images/issues/11101