### PR TITLE
Fix Session.close() to prevent freeing underlying session

### DIFF
--- a/docs/changelog-fragments/709.bugfix.rst
+++ b/docs/changelog-fragments/709.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed crash when more operations were called after ``session.close()`` -- by :user:`Jakuje`.

--- a/src/pylibsshext/session.pyx
+++ b/src/pylibsshext/session.pyx
@@ -539,8 +539,6 @@ cdef class Session(object):
         if self._libssh_session is not NULL:
             if libssh.ssh_is_connected(self._libssh_session):
                 libssh.ssh_disconnect(self._libssh_session)
-            libssh.ssh_free(self._libssh_session)
-            self._libssh_session = NULL
 
     def set_missing_host_key_policy(self, policy):
         """The policy to use if the know host key is missing.

--- a/tests/unit/session_test.py
+++ b/tests/unit/session_test.py
@@ -13,6 +13,15 @@ def test_make_session():
     assert Session()
 
 
+def test_make_session_close_connect():
+    """Make sure the session is usable after call to close()."""
+    session = Session()
+    session.close()
+    error_msg = '^ssh connect failed: Hostname required$'
+    with pytest.raises(LibsshSessionException, match=error_msg):
+        session.connect()
+
+
 def test_session_connection_refused(free_port_num):
     """Test that connecting to a missing service raises an error."""
     error_msg = '^ssh connect failed: Connection refused$'


### PR DESCRIPTION
##### SUMMARY
Call to connect() after close() crashed, likely because the NULL pointer was passed somewhere it should not.

The session should really be freed only in the destructor so removing the offending code.

Fixes: #702

##### ISSUE TYPE
- Bugfix Pull Request