### PR TITLE
🧪 Disable `fail-fast` in CI when in debug mode

### DIFF
--- a/.github/workflows/build-manylinux-container-images.yml
+++ b/.github/workflows/build-manylinux-container-images.yml
@@ -33,7 +33,7 @@ jobs:
     outputs:
       # NOTE: These aren't env vars because the `${{ env }}` context is
       # NOTE: inaccessible when passing inputs to reusable workflows.
-      is-debug-mode: ${{ runner.debug == '1' && false || true }}
+      is-debug-mode: ${{ toJSON(runner.debug == '1') }}
 
     steps:
     - name: No-op so that the computations can happen in the outputs

--- a/.github/workflows/build-manylinux-container-images.yml
+++ b/.github/workflows/build-manylinux-container-images.yml
@@ -19,12 +19,43 @@ on:  # yamllint disable-line rule:truthy
     - build-scripts/manylinux-container-image/**
 
 jobs:
+  pre-setup:
+    name: ⚙️ Pre-set global build settings
+
+    runs-on: ubuntu-latest
+
+    timeout-minutes: 1
+
+    defaults:
+      run:
+        shell: python
+
+    outputs:
+      # NOTE: These aren't env vars because the `${{ env }}` context is
+      # NOTE: inaccessible when passing inputs to reusable workflows.
+      is-debug-mode: ${{ runner.debug == '1' && false || true }}
+
+    steps:
+    - name: No-op so that the computations can happen in the outputs
+      if: fromJSON(false)
+      run: |
+        print('No-op')
+
   build:
+    needs:
+    - pre-setup
+
     runs-on: ubuntu-latest
 
     timeout-minutes: 120
 
     strategy:
+      fail-fast: >-  # ${{ runner.debug }} is unavailable in this context
+        ${{
+          fromJSON(needs.pre-setup.outputs.is-debug-mode)
+          && false
+          || true
+        }}
       matrix:
         IMAGE:
         # Build containers for x86_64

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -158,6 +158,7 @@ jobs:
       git-tag: ${{ steps.git-tag.outputs.tag }}
       sdist-artifact-name: ${{ steps.artifact-name.outputs.sdist }}
       wheel-artifact-name: ${{ steps.artifact-name.outputs.wheel }}
+      is-debug-mode: ${{ runner.debug == '1' && false || true }}
       changelog-patch-name: ${{ steps.changelog-patch-name.outputs.filename }}
       changelog-draft-name-md: >-
         ${{ steps.changelog-draft-name.outputs.filename-base }}.md
@@ -626,6 +627,12 @@ jobs:
     - build-src
     - pre-setup  # transitive, for accessing settings
     strategy:
+      fail-fast: >-  # ${{ runner.debug }} is unavailable in this context
+        ${{
+          fromJSON(needs.pre-setup.outputs.is-debug-mode)
+          && false
+          || true
+        }}
       matrix:
         os:
         - macos-13
@@ -762,6 +769,12 @@ jobs:
     timeout-minutes: 2
 
     strategy:
+      fail-fast: >-  # ${{ runner.debug }} is unavailable in this context
+        ${{
+          fromJSON(needs.pre-setup.outputs.is-debug-mode)
+          && false
+          || true
+        }}
       matrix:
         python-version:
         - >-
@@ -961,6 +974,12 @@ jobs:
     - build-src
     - pre-setup  # transitive, for accessing settings
     strategy:
+      fail-fast: >-  # ${{ runner.debug }} is unavailable in this context
+        ${{
+          fromJSON(needs.pre-setup.outputs.is-debug-mode)
+          && false
+          || true
+        }}
       matrix:
         target-container:
         - tag: fedora:39
@@ -1234,6 +1253,12 @@ jobs:
     - build-src
     - pre-setup  # transitive, for accessing settings
     strategy:
+      fail-fast: >-  # ${{ runner.debug }} is unavailable in this context
+        ${{
+          fromJSON(needs.pre-setup.outputs.is-debug-mode)
+          && false
+          || true
+        }}
       matrix:
         python-version:
         - "3.12"
@@ -1271,6 +1296,12 @@ jobs:
     - build-src
     - pre-setup  # transitive, for accessing settings
     strategy:
+      fail-fast: >-  # ${{ runner.debug }} is unavailable in this context
+        ${{
+          fromJSON(needs.pre-setup.outputs.is-debug-mode)
+          && false
+          || true
+        }}
       matrix:
         python-version:
         - "3.12"

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -158,7 +158,7 @@ jobs:
       git-tag: ${{ steps.git-tag.outputs.tag }}
       sdist-artifact-name: ${{ steps.artifact-name.outputs.sdist }}
       wheel-artifact-name: ${{ steps.artifact-name.outputs.wheel }}
-      is-debug-mode: ${{ runner.debug == '1' && false || true }}
+      is-debug-mode: ${{ toJSON(runner.debug == '1') }}
       changelog-patch-name: ${{ steps.changelog-patch-name.outputs.filename }}
       changelog-draft-name-md: >-
         ${{ steps.changelog-draft-name.outputs.filename-base }}.md

--- a/docs/changelog-fragments/710.contrib.rst
+++ b/docs/changelog-fragments/710.contrib.rst
@@ -1,0 +1,9 @@
+The CI will now stop auto-cancelling matrix jobs on failures
+when debug mode is requested. This requires restarting the
+entire workflow run because this flag is computed in the
+very first job.
+
+Debug mode can be requested through the restart button or by
+setting supported repository variable or secret values.
+
+-- by :user:`webknjaz`


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
$sbj. This will let us get logs of all matrix jobs without in-matrix cancellations.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
N/A