### PR TITLE
🧪 Use `tonistiigi/binfmt` QEMU container image

### DIFF
--- a/.github/workflows/build-manylinux-container-images.yml
+++ b/.github/workflows/build-manylinux-container-images.yml
@@ -86,11 +86,17 @@ jobs:
         Set up QEMU ${{ env.QEMU_ARCH }} arch emulation
         with Podman
       if: env.QEMU_ARCH != 'amd64'
-      run: >-
+      run: >
         sudo podman run
         --rm --privileged
-        multiarch/qemu-user-static
-        --reset -p yes
+        tonistiigi/binfmt
+        --uninstall 'qemu-*'
+
+
+        sudo podman run
+        --rm --privileged
+        tonistiigi/binfmt
+        --install all
     - name: Build the image with Buildah
       id: build-image
       uses: redhat-actions/buildah-build@v2.13

--- a/build-scripts/manylinux-container-image/install-userspace-tools.sh
+++ b/build-scripts/manylinux-container-image/install-userspace-tools.sh
@@ -11,17 +11,13 @@ PYTHON_INTERPRETER=/opt/python/cp39-cp39/bin/python
 VIRTUALENV_PYTHON_BIN="${USERSPACE_VENV_BIN_PATH}/python"
 VIRTUALENV_PIP_BIN="${VIRTUALENV_PYTHON_BIN} -m pip"
 
-TOOLS_PKGS=auditwheel
-if [ "${ARCH}" == "x86_64" ]
-then
-    # NOTE: Cmake removed compatibility with `cmake < 3.5` that
-    # NOTE: libssh 0.9.6 is set up to require.
-    # NOTE: So this patch limits the version of `cmake` we install.
-    #
-    # Ref: https://github.com/eclipse-ecal/ecal/issues/2041
-    # FIXME: Drop the restriction once libssh is bumped to v0.11 series.
-    TOOLS_PKGS="${TOOLS_PKGS} cmake<4 --only-binary=cmake"
-fi
+# NOTE: Cmake removed compatibility with `cmake < 3.5` that
+# NOTE: libssh 0.9.6 is set up to require.
+# NOTE: So this patch limits the version of `cmake` we install.
+#
+# Ref: https://github.com/eclipse-ecal/ecal/issues/2041
+# FIXME: Drop the restriction once libssh is bumped to v0.11 series.
+TOOLS_PKGS="auditwheel cmake<4 --only-binary=cmake"
 
 # Avoid creation of __pycache__/*.py[c|o]
 export PYTHONDONTWRITEBYTECODE=1

--- a/build-scripts/manylinux-container-image/install-userspace-tools.sh
+++ b/build-scripts/manylinux-container-image/install-userspace-tools.sh
@@ -14,7 +14,13 @@ VIRTUALENV_PIP_BIN="${VIRTUALENV_PYTHON_BIN} -m pip"
 TOOLS_PKGS=auditwheel
 if [ "${ARCH}" == "x86_64" ]
 then
-    TOOLS_PKGS="${TOOLS_PKGS} cmake --only-binary=cmake"
+    # NOTE: Cmake removed compatibility with `cmake < 3.5` that
+    # NOTE: libssh 0.9.6 is set up to require.
+    # NOTE: So this patch limits the version of `cmake` we install.
+    #
+    # Ref: https://github.com/eclipse-ecal/ecal/issues/2041
+    # FIXME: Drop the restriction once libssh is bumped to v0.11 series.
+    TOOLS_PKGS="${TOOLS_PKGS} cmake<4 --only-binary=cmake"
 fi
 
 # Avoid creation of __pycache__/*.py[c|o]

--- a/docs/changelog-fragments/713.contrib.rst
+++ b/docs/changelog-fragments/713.contrib.rst
@@ -1,0 +1,5 @@
+The ``multiarch/qemu-user-static`` image got replaced with
+``tonistiigi/binfmt`` because the latter is no longer
+maintained and the former includes the fixed version of QEMU.
+
+-- by :user:`webknjaz`

--- a/docs/changelog-fragments/713.packaging.rst
+++ b/docs/changelog-fragments/713.packaging.rst
@@ -1,0 +1,2 @@
+The ``manylinux`` build scripts now limit ``cmake`` below
+version 4 -- by :user:`webknjaz`.


### PR DESCRIPTION
This replaces `multiarch/qemu-user-static` that hasn't gotten a release in over two years. And fixes the breakage that occurred as a result of GitHub Actions CI/CD updating their Ubuntu VMs [[1]].

[1]: https://github.com/actions/runner-images/issues/11662

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
$sbj.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
N/A