### PR TITLE
rpm: Stop skipping scp tests

### DIFF
--- a/docs/changelog-fragments/714.packaging.rst
+++ b/docs/changelog-fragments/714.packaging.rst
@@ -1,0 +1,1 @@
+Stopped skipping SCP tests in the RPM spec -- by :user:`Jakuje`.

--- a/packaging/rpm/ansible-pylibssh.spec
+++ b/packaging/rpm/ansible-pylibssh.spec
@@ -230,17 +230,12 @@ export PYTHONPATH="%{buildroot_site_packages}:${PYTHONPATH}"
 # Fedora:
 %if "%{?fedora:SET}" == "SET"
 %pyproject_check_import
-%tox -e just-pytest -- \
-  -- \
-  --deselect tests/unit/scp_test.py::test_get \
-  --deselect tests/unit/scp_test.py::test_put
+%tox -e just-pytest
 # CentOS or RHEL:
 %else
 export PYTHONPATH="$(pwd)/bin:${PYTHONPATH}"
 %{__python3} -m pytest \
-  --no-cov \
-  --deselect tests/unit/scp_test.py::test_get \
-  --deselect tests/unit/scp_test.py::test_put
+  --no-cov
 %endif
 
 


### PR DESCRIPTION
##### SUMMARY
Seems like over the recent changes the SCP tests were fixed and there is no need to skip them during the rpm build.

If not, we will see in this PR :)

##### ISSUE TYPE
- Bugfix Pull Request