### PR TITLE
ci: Add Fedora 41 and 42

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -965,6 +965,8 @@ jobs:
         target-container:
         - tag: fedora:39
         - tag: fedora:40
+        - tag: fedora:41
+        - tag: fedora:42
         # No matching package to install: 'python3dist(wheel)'
         # - tag: centos/centos:stream9
         #   registry: quay.io

--- a/docs/changelog-fragments/715.contrib.rst
+++ b/docs/changelog-fragments/715.contrib.rst
@@ -1,0 +1,1 @@
+Added Fedora 41 and 42 to CI configuration -- by :user:`Jakuje`.


### PR DESCRIPTION
##### SUMMARY
The Fedora 42 was released two weeks ago.

##### ISSUE TYPE
- Bugfix Pull Request