### PR TITLE
ci: Remove unused patching of centos8 stream repository

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1013,17 +1013,6 @@ jobs:
         dist_tag=$(rpm --eval '%{?dist}')
         echo "dist-tag=${dist_tag}" >> "${GITHUB_OUTPUT}"
 
-    - name: Patch CentOS Stream 8 repository URLs
-      if: >-
-        matrix.target-container.tag == 'centos/centos:stream8'
-      run: >-
-        sed -i
-        -e 's/mirrorlist/#mirrorlist/g'
-        -e
-        's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g'
-        /etc/yum.repos.d/CentOS-*
-      shell: bash -eEuo pipefail {0}
-
     - name: Enable EPEL repository
       if: contains(matrix.target-container.tag, 'centos')
       run: dnf install --assumeyes epel-release

--- a/docs/changelog-fragments/716.contrib.rst
+++ b/docs/changelog-fragments/716.contrib.rst
@@ -1,0 +1,1 @@
+Removed needless step from CI adjusting centos8 repositories -- by :user:`Jakuje`.


### PR DESCRIPTION
##### SUMMARY
The CentOS 8 stream pipelines were removed some time ago, but the patching stayed. Removing will make the pipeline slightly easier to read and go through

##### ISSUE TYPE
- Bugfix Pull Request