### PR TITLE
🐋 Build aarch64 images on ARM64-native runners

### DIFF
--- a/.github/workflows/build-manylinux-container-images.yml
+++ b/.github/workflows/build-manylinux-container-images.yml
@@ -20,7 +20,7 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.IMAGE.HOST_OS || 'ubuntu-latest' }}
 
     timeout-minutes: 45
 
@@ -33,7 +33,7 @@ jobs:
           QEMU_ARCH: amd64
         # Build containers for aarch64 (ARM 64)
         - ARCH: aarch64
-          QEMU_ARCH: arm64
+          HOST_OS: ubuntu-24.04-arm
         # Build containers for ppc64le
         - ARCH: ppc64le
         # Build containers for s390x

--- a/docs/changelog-fragments/731.contrib.rst
+++ b/docs/changelog-fragments/731.contrib.rst
@@ -1,0 +1,2 @@
+The host OS is now ARM-based when building ``manylinux_*_*_aarch64``
+images for CI/CD -- by :user:`webknjaz`.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
SSIA

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request
- Packaging Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
N/A. This speeds up the aarch64 image builds from 30–40 minutes to 2–3 minutes.