### PR TITLE
🧪 Hide false negative warnings by `coveragepy`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -28,6 +28,23 @@ show_missing = true
 [run]
 branch = true
 cover_pylib = false
+# NOTE: `disable_warnings` is needed when `pytest-cov` runs in tandem
+# NOTE: with `pytest-xdist`. These warnings are false negative in this
+# NOTE: context.
+#
+# NOTE: It's `coveragepy` that emits the warnings and previously they
+# NOTE: wouldn't get on the radar of `pytest`'s `filterwarnings`
+# NOTE: mechanism. This changed, however, with `pytest >= 8.4`. And
+# NOTE: since we set `filterwarnings = error`, those warnings are being
+# NOTE: raised as exceptions, cascading into `pytest`'s internals and
+# NOTE: causing tracebacks and crashes of the test sessions.
+#
+# Ref:
+# * https://github.com/pytest-dev/pytest-cov/issues/693
+# * https://github.com/pytest-dev/pytest-cov/pull/695
+# * https://github.com/pytest-dev/pytest-cov/pull/696
+disable_warnings =
+  module-not-measured
 plugins =
 #   covdefaults
   Cython.Coverage

--- a/docs/changelog-fragments/732.contrib.rst
+++ b/docs/changelog-fragments/732.contrib.rst
@@ -1,0 +1,7 @@
+False negative warnings reported by ``coveragepy`` when are now
+disabled. They are evident when ``pytest-cov`` runs with the
+``pytest-xdist`` integration. ``pytest`` 8.4 gives them more
+visibility and out ``filterwarnings = error`` setting was turning
+them into errors before this change.
+
+-- by :user:`webknjaz`


### PR DESCRIPTION
They are only surfaced under pytest 8.4, with `pytest-cov` and `pytest-xdist` being both active [[1]].

[1]: https://github.com/pytest-dev/pytest-cov/issues/693

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
$sbj.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

https://github.com/pytest-dev/pytest-cov/issues/693#issuecomment-2948814898