### PR TITLE
🧪 Drop GHA jobs w/ sdist install @ Python 3.12+

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1236,6 +1236,18 @@ jobs:
         dist-type:
         - binary
         - source
+        exclude:
+        # NOTE: Python 3.12+ with installs from sdist hits a bug in tox
+        # NOTE: which makes it fail until GHA times out. This is why the
+        # NOTE: following exclusions are in place. They should be
+        # NOTE: removed once tox fixes said bug.
+        # Ref: https://github.com/tox-dev/tox/issues/3512
+        - python-version: 3.14
+          dist-type: source
+        - python-version: 3.13
+          dist-type: source
+        - python-version: 3.12
+          dist-type: source
 
     uses: ./.github/workflows/reusable-tests.yml
     with:
@@ -1271,6 +1283,18 @@ jobs:
         dist-type:
         - binary
         - source
+        exclude:
+        # NOTE: Python 3.12+ with installs from sdist hits a bug in tox
+        # NOTE: which makes it fail until GHA times out. This is why the
+        # NOTE: following exclusions are in place. They should be
+        # NOTE: removed once tox fixes said bug.
+        # Ref: https://github.com/tox-dev/tox/issues/3512
+        - python-version: 3.14
+          dist-type: source
+        - python-version: 3.13
+          dist-type: source
+        - python-version: 3.12
+          dist-type: source
 
     uses: ./.github/workflows/reusable-tests.yml
     with:

--- a/docs/changelog-fragments/733.contrib.rst
+++ b/docs/changelog-fragments/733.contrib.rst
@@ -1,0 +1,6 @@
+GitHub Actions CI/CD no longer runs jobs that install source
+distributions into the tox environments for testing
+-- by :user:`webknjaz`.
+
+This is a temporary workaround for an upstream bug in tox and
+said jobs are non-essential.


### PR DESCRIPTION
This patch stops running jobs that exhibit the tox bug that makes them hang indefinitely [[1]].

[1]: https://github.com/tox-dev/tox/issues/3512

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
SSIA

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
N/A