### PR TITLE
Start bundling `libssh` v0.11.1 in `manylinux` wheels

### DIFF
--- a/docs/changelog-fragments/735.packaging.rst
+++ b/docs/changelog-fragments/735.packaging.rst
@@ -1,0 +1,2 @@
+Started bundling a copy of libssh 0.11.1 in platform-specific
+wheels published on PyPI -- by :user:`Jakuje`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,10 +161,10 @@ PRE_COMMIT_COLOR = "always"
 PY_COLORS = "1"
 
 [tool.cibuildwheel.linux]
-manylinux-aarch64-image = "ghcr.io/ansible/pylibssh-manylinux_2_28_aarch64:libssh-v0.9.6"
-manylinux-ppc64le-image = "ghcr.io/ansible/pylibssh-manylinux_2_28_ppc64le:libssh-v0.9.6"
-manylinux-s390x-image = "ghcr.io/ansible/pylibssh-manylinux_2_28_s390x:libssh-v0.9.6"
-manylinux-x86_64-image = "ghcr.io/ansible/pylibssh-manylinux_2_28_x86_64:libssh-v0.9.6"
+manylinux-aarch64-image = "ghcr.io/ansible/pylibssh-manylinux_2_28_aarch64:libssh-v0.11.1"
+manylinux-ppc64le-image = "ghcr.io/ansible/pylibssh-manylinux_2_28_ppc64le:libssh-v0.11.1"
+manylinux-s390x-image = "ghcr.io/ansible/pylibssh-manylinux_2_28_s390x:libssh-v0.11.1"
+manylinux-x86_64-image = "ghcr.io/ansible/pylibssh-manylinux_2_28_x86_64:libssh-v0.11.1"
 skip = [
   "*-musllinux_*",  # FIXME: musllinux needs us to provide with containers pre-built libssh
   "pp*",  # FIXME: we don't ship these currently but could


### PR DESCRIPTION
##### SUMMARY
Update the release script/packaging infrastructure to use the new libssh-0.11.1 based images.

##### ISSUE TYPE
- Feature Pull Request

##### ADDITIONAL INFORMATION
Depends on #734 and #636.