### PR TITLE
contrib: Remove workaround keeping old cmake version

### DIFF
--- a/build-scripts/manylinux-container-image/install-userspace-tools.sh
+++ b/build-scripts/manylinux-container-image/install-userspace-tools.sh
@@ -11,13 +11,7 @@ PYTHON_INTERPRETER=/opt/python/cp39-cp39/bin/python
 VIRTUALENV_PYTHON_BIN="${USERSPACE_VENV_BIN_PATH}/python"
 VIRTUALENV_PIP_BIN="${VIRTUALENV_PYTHON_BIN} -m pip"
 
-# NOTE: Cmake removed compatibility with `cmake < 3.5` that
-# NOTE: libssh 0.9.6 is set up to require.
-# NOTE: So this patch limits the version of `cmake` we install.
-#
-# Ref: https://github.com/eclipse-ecal/ecal/issues/2041
-# FIXME: Drop the restriction once libssh is bumped to v0.11 series.
-TOOLS_PKGS="auditwheel cmake<4 --only-binary=cmake"
+TOOLS_PKGS="auditwheel cmake --only-binary=cmake"
 
 # Avoid creation of __pycache__/*.py[c|o]
 export PYTHONDONTWRITEBYTECODE=1

--- a/docs/changelog-fragments/737.contrib.rst
+++ b/docs/changelog-fragments/737.contrib.rst
@@ -1,0 +1,2 @@
+Reverted workaround keeping the old CMake version installed
+as the new ``libssh`` works with newer versions -- by :user:`Jakuje`.


### PR DESCRIPTION
##### SUMMARY
Reverts changes made to the cmake installation in ae27ea1b4a3d1565846b9e7a405d4cf2c002e91f and d22a05ea1038f58cd9a92f9c12fa5e665289cf2a.


##### ISSUE TYPE
- Bugfix Pull Request