### PR TITLE
Update OpenSSL to 3.5.0 in manylinux

### DIFF
--- a/.github/workflows/build-manylinux-container-images.yml
+++ b/.github/workflows/build-manylinux-container-images.yml
@@ -22,7 +22,7 @@ jobs:
   build:
     runs-on: ${{ matrix.IMAGE.HOST_OS || 'ubuntu-latest' }}
 
-    timeout-minutes: 45
+    timeout-minutes: 50
 
     strategy:
       matrix:

--- a/build-scripts/manylinux-container-image/Dockerfile
+++ b/build-scripts/manylinux-container-image/Dockerfile
@@ -4,6 +4,27 @@ ARG RELEASE
 ARG LIBSSH_VERSION=0.11.1
 MAINTAINER Python Cryptographic Authority
 WORKDIR /root
+RUN \
+  if [ $(uname -m) != "aarch64" ]; \
+  then \
+    if stat /etc/redhat-release 1>&2 2>/dev/null; then \
+      yum -y install binutils perl perl-IPC-Cmd && \
+      yum -y clean all && \
+      rm -rf /var/cache/yum; \
+    fi; \
+  fi
+
+# This is done as two separate steps because readelf (binutils) is not available on
+# aarch64.
+RUN \
+  if [ $(uname -m) = "aarch64" ]; \
+  then \
+    if stat /etc/redhat-release 1>&2 2>/dev/null; then \
+      yum -y install perl perl-IPC-Cmd && \
+      yum -y clean all && \
+      rm -rf /var/cache/yum; \
+    fi; \
+  fi
 
 ADD build_utils.sh /root/build_utils.sh
 ADD install_perl.sh /root/install_perl.sh

--- a/build-scripts/manylinux-container-image/install_libssh.sh
+++ b/build-scripts/manylinux-container-image/install_libssh.sh
@@ -68,6 +68,8 @@ export LDFLAGS="-pthread -ldl"
 # See also "/tmp/libssh-0.9.4-manylinux-build.FJUercWAg9/libssh-0.9.4/build/CMakeFiles/CMakeError.log".
 export PYCA_OPENSSL_PATH=/opt/pyca/cryptography/openssl
 export PKG_CONFIG_PATH="${STATIC_DEPS_PREFIX}/lib64/pkgconfig:${STATIC_DEPS_PREFIX}/lib/pkgconfig:${PYCA_OPENSSL_PATH}/lib/pkgconfig"
+# Point libssh directly to the OpenSSL directory. It can find it there
+export OPENSSL_ROOT_DIR="${PYCA_OPENSSL_PATH}"
 
 >&2 echo
 >&2 echo

--- a/build-scripts/manylinux-container-image/install_openssl.sh
+++ b/build-scripts/manylinux-container-image/install_openssl.sh
@@ -8,21 +8,28 @@ MY_DIR=$(dirname "${BASH_SOURCE[0]}")
 
 # Get build utilities
 source $MY_DIR/build_utils.sh
+
+OPENSSL_URL="https://github.com/openssl/openssl/releases/download"
 source /root/openssl-version.sh
 
-fetch_source "openssl-${OPENSSL_VERSION}.tar.gz" "https://www.openssl.org/source/"
-check_sha256sum "openssl-${OPENSSL_VERSION}.tar.gz" ${OPENSSL_SHA256}
-tar zxf openssl-${OPENSSL_VERSION}.tar.gz
+curl -#LO "${OPENSSL_URL}/${OPENSSL_VERSION}/${OPENSSL_VERSION}.tar.gz"
+check_sha256sum "${OPENSSL_VERSION}.tar.gz" ${OPENSSL_SHA256}
+tar zxf ${OPENSSL_VERSION}.tar.gz
 
-pushd openssl-${OPENSSL_VERSION}
+pushd ${OPENSSL_VERSION}
+BUILD_FLAGS="$OPENSSL_BUILD_FLAGS"
 if [[ "$1" =~ '^manylinux1_.*$' ]]; then
   PATH=/opt/perl/bin:$PATH
 fi
-./config $OPENSSL_BUILD_FLAGS --prefix=/opt/pyca/cryptography/openssl --openssldir=/opt/pyca/cryptography/openssl
+if [ "$(readelf -h /proc/self/exe | grep -o 'Machine:.* S/390')" ]; then
+    BUILD_FLAGS="$OPENSSL_BUILD_FLAGS_S390X"
+    export CFLAGS="$CFLAGS -march=z10"
+fi
+./config $BUILD_FLAGS --prefix=/opt/pyca/cryptography/openssl --openssldir=/opt/pyca/cryptography/openssl
 make depend
 make -j4
 # avoid installing the docs
 # https://github.com/openssl/openssl/issues/6685#issuecomment-403838728
 make install_sw install_ssldirs
 popd
-rm -rf openssl-${OPENSSL_VERSION}
+rm -rf openssl*

--- a/build-scripts/manylinux-container-image/openssl-version.sh
+++ b/build-scripts/manylinux-container-image/openssl-version.sh
@@ -1,6 +1,7 @@
-export OPENSSL_VERSION="1.1.1k"
-export OPENSSL_SHA256="892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5"
+export OPENSSL_VERSION="openssl-3.5.0"
+export OPENSSL_SHA256="344d0a79f1a9b08029b0744e2cc401a43f9c90acd1044d09a530b4885a8e9fc0"
 # We need a base set of flags because on Windows using MSVC
 # enable-ec_nistp_64_gcc_128 doesn't work since there's no 128-bit type
-export OPENSSL_BUILD_FLAGS_WINDOWS="no-ssl3 no-ssl3-method no-zlib no-shared no-comp no-dynamic-engine"
+export OPENSSL_BUILD_FLAGS_WINDOWS="no-ssl3 no-ssl3-method no-zlib no-shared no-module no-comp no-dynamic-engine no-apps no-docs no-sm2-precomp no-atexit"
+export OPENSSL_BUILD_FLAGS_S390X="${OPENSSL_BUILD_FLAGS_WINDOWS}"
 export OPENSSL_BUILD_FLAGS="${OPENSSL_BUILD_FLAGS_WINDOWS} enable-ec_nistp_64_gcc_128"

--- a/docs/changelog-fragments/738.packaging.rst
+++ b/docs/changelog-fragments/738.packaging.rst
@@ -1,0 +1,2 @@
+Updated the bundled copy of OpenSSL to the latest version 3.5.0
+in ``manylinux`` wheels -- by :user:`Jakuje`.


### PR DESCRIPTION
##### SUMMARY
This also changes the way how the libssh finds the OpenSSL installation to use the `OPENSSL_ROOT_DIR` variable.

Based partially on the changes in #719 and from the https://github.com/pyca/infra/tree/main/cryptography-linux

##### ISSUE TYPE
- Feature Pull Request