### PR TITLE
🧪 Fix artifact URLs in the `dumb-pypi` index

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1888,9 +1888,9 @@ jobs:
       run: |
         python -m dumb_pypi.main \
           --package-list <(ls dist/) \
-          --packages-url https://raw.githubusercontent.com/${{
-            github.repository
-          }}/gh-pages/dist \
+          --packages-url "https://${{
+            github.repository_owner
+          }}.github.io/${GITHUB_REPOSITORY#$GITHUB_REPOSITORY_OWNER/}/dist" \
           --output-dir gh-pages-dumb-pypi
       shell: bash
 

--- a/docs/changelog-fragments/678.contrib.rst
+++ b/docs/changelog-fragments/678.contrib.rst
@@ -1,0 +1,1 @@
+749.contrib.rst

--- a/docs/changelog-fragments/679.contrib.rst
+++ b/docs/changelog-fragments/679.contrib.rst
@@ -1,0 +1,1 @@
+749.contrib.rst

--- a/docs/changelog-fragments/749.contrib.rst
+++ b/docs/changelog-fragments/749.contrib.rst
@@ -1,0 +1,2 @@
+The ``dumb-pypi``-produced static package index now renders correct
+URLs to the distribution packages -- by :user:`webknjaz`.


### PR DESCRIPTION
Looks like migrating the GitHub Pages publishing mechanism from a Git branch to an artifact-based process broke this. It used to point to artifacts on the branch. Now, this patch changes it to point to the public GH Pages URL from the static website.

Resolves #679.