### PR TITLE
🧪 Generalize cibuildwheel workflow for reusablity

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -627,11 +627,11 @@ jobs:
     - pre-setup  # transitive, for accessing settings
     strategy:
       matrix:
-        os:
+        runner-vm-os:
         - macos-13
     uses: ./.github/workflows/reusable-cibuildwheel.yml
     with:
-      os: ${{ matrix.os }}
+      runner-vm-os: ${{ matrix.runner-vm-os }}
       wheel-tags-to-skip: >-
         ${{
         !fromJSON(needs.pre-setup.outputs.release-requested)
@@ -683,7 +683,7 @@ jobs:
     - pre-setup  # transitive, for accessing settings
     uses: ./.github/workflows/reusable-cibuildwheel.yml
     with:
-      os: ubuntu-latest
+      runner-vm-os: ubuntu-latest
       wheel-tags-to-skip: >-
         *_i686
         *-musllinux_*
@@ -720,7 +720,7 @@ jobs:
     - pre-setup  # transitive, for accessing settings
     uses: ./.github/workflows/reusable-cibuildwheel.yml
     with:
-      os: ubuntu-latest
+      runner-vm-os: ubuntu-latest
       wheel-tags-to-skip: >-
         *_i686
         *-musllinux_*

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -633,35 +633,34 @@ jobs:
     with:
       runner-vm-os: ${{ matrix.runner-vm-os }}
       timeout-minutes: 9
-      wheel-tags-to-skip: >-
-        ${{
-        !fromJSON(needs.pre-setup.outputs.release-requested)
-        && '*_i686
-        *-macosx_universal2
-        *-musllinux_*
-        *-win32
-        *_arm64
-        pp*'
-        || ''
-        }}
       source-tarball-name: >-
         ${{ needs.pre-setup.outputs.sdist-artifact-name }}
       dists-artifact-name: >-
         ${{ needs.pre-setup.outputs.dists-artifact-name }}
-      # cython-tracing: >-  # Cython line tracing for coverage collection
-      #   ${{
-      #     (
-      #       github.event_name == 'push'
-      #       && contains(github.ref, 'refs/tags/')
-      #     )
-      #     && 'false'
-      #     || 'true'
-      #   }}
-      cython-tracing: >-  # Cython line tracing for coverage collection
-        ${{
+      # CIBW_CONFIG_SETTINGS: `with-cython-tracing` — for coverage collection
+      # CIBW_ARCHS_MACOS=all x86_64 arm64 universal2
+      environment-variables: |-
+        CIBW_ARCHS_MACOS=native
+
+        CIBW_CONFIG_SETTINGS<<EOF
+        with-cython-tracing=${{
           fromJSON(needs.pre-setup.outputs.profiling-enabled)
           && 'true'
           || 'false'
+        }}
+        EOF
+
+        ${{
+          !fromJSON(needs.pre-setup.outputs.release-requested)
+          && 'CIBW_SKIP<<EOF
+          *_i686
+          *-macosx_universal2
+          *-musllinux_*
+          *-win32
+          *_arm64
+          pp*
+        EOF'
+          || ''
         }}
 
   build-bin-manylinux-tested-arches:
@@ -686,20 +685,32 @@ jobs:
     with:
       runner-vm-os: ubuntu-latest
       timeout-minutes: 9
-      wheel-tags-to-skip: >-
-        *_i686
-        *-musllinux_*
-        *-*linux_{aarch64,ppc64le,s390x}
-        pp*
       source-tarball-name: >-
         ${{ needs.pre-setup.outputs.sdist-artifact-name }}
       dists-artifact-name: >-
         ${{ needs.pre-setup.outputs.dists-artifact-name }}
-      cython-tracing: >-  # Cython line tracing for coverage collection
-        ${{
+      # CIBW_CONFIG_SETTINGS: `with-cython-tracing` — for coverage collection
+      # CIBW_ARCHS_MACOS=all x86_64 arm64 universal2
+      environment-variables: |-
+        CIBW_ARCHS_MACOS=native
+
+        CIBW_CONFIG_SETTINGS<<EOF
+        with-cython-tracing=${{
           fromJSON(needs.pre-setup.outputs.profiling-enabled)
           && 'true'
           || 'false'
+        }}
+        EOF
+
+        ${{
+          !fromJSON(needs.pre-setup.outputs.release-requested)
+          && 'CIBW_SKIP<<EOF
+          *_i686
+          *-musllinux_*
+          *-*linux_{aarch64,ppc64le,s390x}
+          pp*
+        EOF'
+          || ''
         }}
 
   build-bin-manylinux-odd-arches:
@@ -724,21 +735,36 @@ jobs:
     with:
       runner-vm-os: ubuntu-latest
       timeout-minutes: 70
-      wheel-tags-to-skip: >-
-        *_i686
-        *-musllinux_*
-        *-*linux_x86_64
-        pp*
       source-tarball-name: >-
         ${{ needs.pre-setup.outputs.sdist-artifact-name }}
       dists-artifact-name: >-
         ${{ needs.pre-setup.outputs.dists-artifact-name }}
-      qemu: all
-      cython-tracing: >-  # Cython line tracing for coverage collection
-        ${{
+      qemu: true
+      # CIBW_ARCHS_LINUX: Build emulated architectures if QEMU, else "auto"
+      # CIBW_CONFIG_SETTINGS: `with-cython-tracing` — for coverage collection
+      # CIBW_ARCHS_MACOS=all x86_64 arm64 universal2
+      environment-variables: |-
+        CIBW_ARCHS_LINUX=all
+
+        CIBW_ARCHS_MACOS=native
+
+        CIBW_CONFIG_SETTINGS<<EOF
+        with-cython-tracing=${{
           fromJSON(needs.pre-setup.outputs.profiling-enabled)
           && 'true'
           || 'false'
+        }}
+        EOF
+
+        ${{
+          !fromJSON(needs.pre-setup.outputs.release-requested)
+          && 'CIBW_SKIP<<EOF
+          *_i686
+          *-musllinux_*
+          *-*linux_x86_64
+          pp*
+        EOF'
+          || ''
         }}
 
   build-src:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -632,6 +632,7 @@ jobs:
     uses: ./.github/workflows/reusable-cibuildwheel.yml
     with:
       runner-vm-os: ${{ matrix.runner-vm-os }}
+      timeout-minutes: 9
       wheel-tags-to-skip: >-
         ${{
         !fromJSON(needs.pre-setup.outputs.release-requested)
@@ -684,6 +685,7 @@ jobs:
     uses: ./.github/workflows/reusable-cibuildwheel.yml
     with:
       runner-vm-os: ubuntu-latest
+      timeout-minutes: 9
       wheel-tags-to-skip: >-
         *_i686
         *-musllinux_*
@@ -721,6 +723,7 @@ jobs:
     uses: ./.github/workflows/reusable-cibuildwheel.yml
     with:
       runner-vm-os: ubuntu-latest
+      timeout-minutes: 70
       wheel-tags-to-skip: >-
         *_i686
         *-musllinux_*

--- a/.github/workflows/reusable-cibuildwheel.yml
+++ b/.github/workflows/reusable-cibuildwheel.yml
@@ -13,16 +13,19 @@ on:  # yamllint disable-line rule:truthy
         description: A custom name for the Checks API-reported status
         required: false
         type: string
-      cython-tracing:
-        description: Whether to build Cython modules with line tracing
-        default: '0'
+      environment-variables:
+        description: >-
+          A newline-delimited blob of text with environment variables
+          to be set using `${GITHUB_ENV}`
         required: false
         type: string
       qemu:
-        description: Emulated QEMU architecture
-        default: ''
+        default: false
+        description: >-
+          Whether this job needs to configure QEMU to emulate a foreign
+          architecture before running `cibuildwheel`. Defaults to "false".
         required: false
-        type: string
+        type: boolean
       runner-vm-os:
         description: VM OS to use
         default: ubuntu-latest
@@ -36,11 +39,6 @@ on:  # yamllint disable-line rule:truthy
         description: Deadline for the job to complete
         required: true
         type: number
-      wheel-tags-to-skip:
-        description: Wheel tags to skip building
-        default: ''
-        required: false
-        type: string
 
 env:
   FORCE_COLOR: "1"  # Make tools pretty.
@@ -54,11 +52,22 @@ jobs:
       ${{
         inputs.check-name
         && inputs.check-name
-        || format('Build wheels on {0} {1}', inputs.runner-vm-os, inputs.qemu)
+        || format(
+          'Build wheels on {0}{1}',
+          inputs.runner-vm-os,
+          inputs.qemu && ' under QEMU' || ''
+        )
       }}
     runs-on: ${{ inputs.runner-vm-os }}
     timeout-minutes: ${{ fromJSON(inputs.timeout-minutes) }}
     steps:
+    - name: Export requested job-global environment variables
+      if: inputs.environment-variables != ''
+      env:
+        INPUT_ENVIRONMENT_VARIABLES: ${{ inputs.environment-variables }}
+      run: echo "${INPUT_ENVIRONMENT_VARIABLES}" >> "${GITHUB_ENV}"
+      shell: bash
+
     - name: Compute GHA artifact name ending
       id: gha-artifact-name
       run: |
@@ -89,35 +98,16 @@ jobs:
       uses: docker/setup-qemu-action@v3
       with:
         platforms: all
-      id: qemu
-    - name: Prepare emulation
-      if: inputs.qemu
-      run: |
-        # Build emulated architectures only if QEMU is set,
-        # use default "auto" otherwise
-        echo "CIBW_ARCHS_LINUX=${{ inputs.qemu }}" >> "${GITHUB_ENV}"
-      shell: bash
-
-    - name: Skip building some wheel tags
-      if: inputs.wheel-tags-to-skip
-      run: |
-        echo "CIBW_SKIP=${{ inputs.wheel-tags-to-skip }}" >> "${GITHUB_ENV}"
-      shell: bash
 
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.17.0
-      env:
-        # CIBW_ARCHS_MACOS: all x86_64 arm64 universal2
-        CIBW_ARCHS_MACOS: native
-        CIBW_CONFIG_SETTINGS: >-  # Cython line tracing for coverage collection
-          with-cython-tracing=${{ inputs.cython-tracing }}
 
     - name: Upload built artifacts for testing and publishing
       uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.dists-artifact-name }}-
           ${{ inputs.runner-vm-os }}-
-          ${{ inputs.qemu }}-
+          ${{ inputs.qemu && 'qemu-' || '' }}
           ${{ steps.gha-artifact-name.outputs.hash }}
         path: ./wheelhouse/*.whl
 

--- a/.github/workflows/reusable-cibuildwheel.yml
+++ b/.github/workflows/reusable-cibuildwheel.yml
@@ -32,6 +32,10 @@ on:  # yamllint disable-line rule:truthy
         description: Sdist filename wildcard
         required: true
         type: string
+      timeout-minutes:
+        description: Deadline for the job to complete
+        required: true
+        type: number
       wheel-tags-to-skip:
         description: Wheel tags to skip building
         default: ''
@@ -53,7 +57,7 @@ jobs:
         || format('Build wheels on {0} {1}', inputs.runner-vm-os, inputs.qemu)
       }}
     runs-on: ${{ inputs.runner-vm-os }}
-    timeout-minutes: ${{ inputs.qemu && 70 || 9 }}
+    timeout-minutes: ${{ fromJSON(inputs.timeout-minutes) }}
     steps:
     - name: Compute GHA artifact name ending
       id: gha-artifact-name

--- a/.github/workflows/reusable-cibuildwheel.yml
+++ b/.github/workflows/reusable-cibuildwheel.yml
@@ -18,14 +18,14 @@ on:  # yamllint disable-line rule:truthy
         default: '0'
         required: false
         type: string
-      os:
-        description: VM OS to use, without version suffix
-        default: ubuntu
-        required: false
-        type: string
       qemu:
         description: Emulated QEMU architecture
         default: ''
+        required: false
+        type: string
+      runner-vm-os:
+        description: VM OS to use
+        default: ubuntu-latest
         required: false
         type: string
       source-tarball-name:
@@ -50,9 +50,9 @@ jobs:
       ${{
         inputs.check-name
         && inputs.check-name
-        || format('Build wheels on {0} {1}', inputs.os, inputs.qemu)
+        || format('Build wheels on {0} {1}', inputs.runner-vm-os, inputs.qemu)
       }}
-    runs-on: ${{ inputs.os }}
+    runs-on: ${{ inputs.runner-vm-os }}
     timeout-minutes: ${{ inputs.qemu && 70 || 9 }}
     steps:
     - name: Compute GHA artifact name ending
@@ -112,7 +112,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.dists-artifact-name }}-
-          ${{ inputs.os }}-
+          ${{ inputs.runner-vm-os }}-
           ${{ inputs.qemu }}-
           ${{ steps.gha-artifact-name.outputs.hash }}
         path: ./wheelhouse/*.whl

--- a/docs/changelog-fragments/750.contrib.rst
+++ b/docs/changelog-fragments/750.contrib.rst
@@ -1,0 +1,3 @@
+The :file:`reusable-cibuildwheel.yml` workflow has been refactored to
+be more generic and :file:`ci-cd.yml` now holds all the configuration
+toggles -- by :user:`webknjaz`.


### PR DESCRIPTION
This includes having input names in line with `reusable-tox.yml` and configuring `cibuildwheel` via env vars passed through inputs.