### PR TITLE
Start bundling libssh 0.11.2 in platform-specific wheels

### DIFF
--- a/docs/changelog-fragments/222.bugfix.rst
+++ b/docs/changelog-fragments/222.bugfix.rst
@@ -1,0 +1,3 @@
+The bundled libssh 0.11.2 no longer fails, when the SFTP server announces
+protocol version 3, but does not provide error message and language tag
+in the ``SSH_FXP_STATUS`` message -- by :user:`Jakuje`.

--- a/docs/changelog-fragments/753.packaging.rst
+++ b/docs/changelog-fragments/753.packaging.rst
@@ -1,0 +1,2 @@
+Updated the bundled version of libssh to 0.11.2 in platform-specific
+wheels published on PyPI -- by :user:`Jakuje`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,10 +161,10 @@ PRE_COMMIT_COLOR = "always"
 PY_COLORS = "1"
 
 [tool.cibuildwheel.linux]
-manylinux-aarch64-image = "ghcr.io/ansible/pylibssh-manylinux_2_28_aarch64:libssh-v0.11.1"
-manylinux-ppc64le-image = "ghcr.io/ansible/pylibssh-manylinux_2_28_ppc64le:libssh-v0.11.1"
-manylinux-s390x-image = "ghcr.io/ansible/pylibssh-manylinux_2_28_s390x:libssh-v0.11.1"
-manylinux-x86_64-image = "ghcr.io/ansible/pylibssh-manylinux_2_28_x86_64:libssh-v0.11.1"
+manylinux-aarch64-image = "ghcr.io/ansible/pylibssh-manylinux_2_28_aarch64:libssh-v0.11.2"
+manylinux-ppc64le-image = "ghcr.io/ansible/pylibssh-manylinux_2_28_ppc64le:libssh-v0.11.2"
+manylinux-s390x-image = "ghcr.io/ansible/pylibssh-manylinux_2_28_s390x:libssh-v0.11.2"
+manylinux-x86_64-image = "ghcr.io/ansible/pylibssh-manylinux_2_28_x86_64:libssh-v0.11.2"
 skip = [
   "*-musllinux_*",  # FIXME: musllinux needs us to provide with containers pre-built libssh
   "pp*",  # FIXME: we don't ship these currently but could


### PR DESCRIPTION
##### SUMMARY
Follow-up to #752 which updated the container images.

Fixes: #222

##### ISSUE TYPE
- Bugfix Pull Request