### PR TITLE
Fix ubi9 builds

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1107,7 +1107,7 @@ jobs:
         --nodeps
         https://rpmfind.net/linux/centos-stream/"$(
           rpm --eval '%{rhel}'
-        )"-stream/CRB/x86_64/os/Packages/python3-pytest-6.2.2-4${{
+        )"-stream/AppStream/x86_64/os/Packages/python3-pytest-6.2.2-6${{
           steps.distribution-meta.outputs.dist-tag
         }}.noarch.rpm
         https://rpmfind.net/linux/centos-stream/"$(

--- a/docs/changelog-fragments/758.contrib.rst
+++ b/docs/changelog-fragments/758.contrib.rst
@@ -1,0 +1,2 @@
+Fixed link to python3-pytest for CentOS 9 Stream as it was recently moved from
+CRB to AppStream -- by :user:`Jakuje`.


### PR DESCRIPTION
##### SUMMARY
ci: python3-pytest was moved to AppStream in CentOS 9

Built on top of #757, which fixes another breakage.

##### ISSUE TYPE
- Bugfix Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
curl: (22) The requested URL returned error: 404
error: skipping https://rpmfind.net/linux/centos-stream/9-stream/CRB/x86_64/os/Packages/python3-pytest-6.2.2-4.el9.noarch.rpm - transfer failed
```
