### PR TITLE
🧪 Stop installing pytest-forked @ cibuildwheel

### DIFF
--- a/docs/changelog-fragments/760.packaging.rst
+++ b/docs/changelog-fragments/760.packaging.rst
@@ -1,0 +1,1 @@
+658.packaging.rst

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,7 @@ profile = "True"
 [tool.cibuildwheel]
 build-frontend = "build"
 # container-engine = "podman"  # FIXME?
-test-requires = "pytest pytest-cov pytest-xdist pytest-forked"
+test-requires = "pytest pytest-cov pytest-xdist"
 test-command = "python -Im pytest -m smoke --no-cov {project}/tests"
 skip = "pp*"
 


### PR DESCRIPTION
It was originally removed from other places in #658. But the `cibuildwheel` was overlooked. This patch corrects that.