### PR TITLE
🧪 Add Ubuntu on ARM into the CI matrix

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -654,9 +654,14 @@ jobs:
     needs:
     - build-src
     - pre-setup  # transitive, for accessing settings
+    strategy:
+      matrix:
+        runner-vm-os:
+        - ubuntu-24.04-arm
+        - ubuntu-latest
     uses: ./.github/workflows/reusable-cibuildwheel.yml
     with:
-      runner-vm-os: ubuntu-latest
+      runner-vm-os: ${{ matrix.runner-vm-os }}
       timeout-minutes: 9
       source-tarball-name: >-
         ${{ needs.pre-setup.outputs.sdist-artifact-name }}
@@ -681,7 +686,7 @@ jobs:
           && 'CIBW_SKIP<<EOF
           *_i686
           *-musllinux_*
-          *-*linux_{aarch64,ppc64le,s390x}
+          *-*linux_{ppc64le,s390x}
           *t-*
         EOF'
           || ''
@@ -738,7 +743,7 @@ jobs:
           *_i686
           *-musllinux_*
           *-*_riscv64
-          *-*linux_x86_64
+          *-*linux_{aarch64,x86_64}
           *t-*
         EOF'
           || ''

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1191,6 +1191,7 @@ jobs:
         - 3.9
         runner-vm-os:
         - ubuntu-24.04
+        - ubuntu-24.04-arm
         - ubuntu-22.04
         dist-type:
         - binary

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -682,9 +682,14 @@ jobs:
     needs:
     - build-src
     - pre-setup  # transitive, for accessing settings
+    strategy:
+      matrix:
+        runner-vm-os:
+        - ubuntu-24.04-arm
+        - ubuntu-latest
     uses: ./.github/workflows/reusable-cibuildwheel.yml
     with:
-      runner-vm-os: ubuntu-latest
+      runner-vm-os: ${{ matrix.runner-vm-os }}
       timeout-minutes: 9
       source-tarball-name: >-
         ${{ needs.pre-setup.outputs.sdist-artifact-name }}
@@ -708,7 +713,7 @@ jobs:
           && 'CIBW_SKIP<<EOF
           *_i686
           *-musllinux_*
-          *-*linux_{aarch64,ppc64le,s390x}
+          *-*linux_{ppc64le,s390x}
           pp*
         EOF'
           || ''
@@ -762,7 +767,7 @@ jobs:
           && 'CIBW_SKIP<<EOF
           *_i686
           *-musllinux_*
-          *-*linux_x86_64
+          *-*linux_{aarch64,x86_64}
           pp*
         EOF'
           || ''

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1213,6 +1213,7 @@ jobs:
         - 3.9
         runner-vm-os:
         - ubuntu-24.04
+        - ubuntu-24.04-arm
         - ubuntu-22.04
         dist-type:
         - binary

--- a/docs/changelog-fragments/674.contrib.rst
+++ b/docs/changelog-fragments/674.contrib.rst
@@ -1,2 +1,5 @@
 The CI now runs testing against ARM Ubuntu VMs that
 GitHub Actions CI/CD provide -- by :user:`webknjaz`.
+
+The dists are now built under native runners instead
+of QEMU which makes the CI resources use efficient.

--- a/docs/changelog-fragments/674.contrib.rst
+++ b/docs/changelog-fragments/674.contrib.rst
@@ -1,0 +1,2 @@
+The CI now runs testing against ARM Ubuntu VMs that
+GitHub Actions CI/CD provide -- by :user:`webknjaz`.

--- a/docs/changelog-fragments/761.contrib.rst
+++ b/docs/changelog-fragments/761.contrib.rst
@@ -1,0 +1,1 @@
+674.contrib.rst


### PR DESCRIPTION
The respective dists are being built already. This patch moves building to faster native ARM runners and makes sure they are also tested.

Resolves #674.