### PR TITLE
Revert "🧪 Drop GHA jobs w/ sdist install @ Python 3.12+"

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1246,18 +1246,6 @@ jobs:
         dist-type:
         - binary
         - source
-        exclude:
-        # NOTE: Python 3.12+ with installs from sdist hits a bug in tox
-        # NOTE: which makes it fail until GHA times out. This is why the
-        # NOTE: following exclusions are in place. They should be
-        # NOTE: removed once tox fixes said bug.
-        # Ref: https://github.com/tox-dev/tox/issues/3512
-        - python-version: 3.14
-          dist-type: source
-        - python-version: 3.13
-          dist-type: source
-        - python-version: 3.12
-          dist-type: source
 
     uses: ./.github/workflows/reusable-tests.yml
     with:
@@ -1293,18 +1281,6 @@ jobs:
         dist-type:
         - binary
         - source
-        exclude:
-        # NOTE: Python 3.12+ with installs from sdist hits a bug in tox
-        # NOTE: which makes it fail until GHA times out. This is why the
-        # NOTE: following exclusions are in place. They should be
-        # NOTE: removed once tox fixes said bug.
-        # Ref: https://github.com/tox-dev/tox/issues/3512
-        - python-version: 3.14
-          dist-type: source
-        - python-version: 3.13
-          dist-type: source
-        - python-version: 3.12
-          dist-type: source
 
     uses: ./.github/workflows/reusable-tests.yml
     with:

--- a/docs/changelog-fragments/764.contrib.rst
+++ b/docs/changelog-fragments/764.contrib.rst
@@ -1,0 +1,4 @@
+The ``requires`` setting has been removed from :file:`tox.ini`, which
+works around the upstream tool bug. This enabled us to re-introduce
+CI jobs testing against sdist under Python 3.12 and newer
+-- by :user:`webknjaz`.

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,6 @@
 [tox]
 envlist = python
 minversion = 3.21.0
-requires =
-  setuptools >= 40.9.0
-  pip >= 19.0.3
-  # tox-venv >= 0.4.0
 isolated_build = true
 
 


### PR DESCRIPTION
This reverts commit d7e5b51dcaf86b4b26a93875d1e302c3d9fd9504.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The upstream issue might have been fixed, according to https://github.com/ansible/pylibssh/issues/721#issuecomment-3249730957.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request