### PR TITLE
Update to libssh 0.11.3 in platform-specific wheels

### DIFF
--- a/docs/changelog-fragments/766.packaging.rst
+++ b/docs/changelog-fragments/766.packaging.rst
@@ -1,0 +1,2 @@
+Updated the bundled version of libssh to 0.11.3 in platform-specific
+wheels published on PyPI -- by :user:`Jakuje`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,10 +161,10 @@ PRE_COMMIT_COLOR = "always"
 PY_COLORS = "1"
 
 [tool.cibuildwheel.linux]
-manylinux-aarch64-image = "ghcr.io/ansible/pylibssh-manylinux_2_28_aarch64:libssh-v0.11.2"
-manylinux-ppc64le-image = "ghcr.io/ansible/pylibssh-manylinux_2_28_ppc64le:libssh-v0.11.2"
-manylinux-s390x-image = "ghcr.io/ansible/pylibssh-manylinux_2_28_s390x:libssh-v0.11.2"
-manylinux-x86_64-image = "ghcr.io/ansible/pylibssh-manylinux_2_28_x86_64:libssh-v0.11.2"
+manylinux-aarch64-image = "ghcr.io/ansible/pylibssh-manylinux_2_28_aarch64:libssh-v0.11.3"
+manylinux-ppc64le-image = "ghcr.io/ansible/pylibssh-manylinux_2_28_ppc64le:libssh-v0.11.3"
+manylinux-s390x-image = "ghcr.io/ansible/pylibssh-manylinux_2_28_s390x:libssh-v0.11.3"
+manylinux-x86_64-image = "ghcr.io/ansible/pylibssh-manylinux_2_28_x86_64:libssh-v0.11.3"
 skip = [
   "*-musllinux_*",  # FIXME: musllinux needs us to provide with containers pre-built libssh
   "pp*",  # FIXME: we don't ship these currently but could


### PR DESCRIPTION
Follow-up to #765

##### SUMMARY
Update to libssh 0.11.3 in platform-specific wheels

##### ISSUE TYPE
- Bugfix Pull Request

##### ADDITIONAL INFORMATION

https://www.libssh.org/2025/09/09/libssh-0-11-3-security-and-bugfix-release/