### PR TITLE
🧪 Switch GHA to `re-actors/cache-python-deps`

### DIFF
--- a/.github/actions/cache-keys/action.yml
+++ b/.github/actions/cache-keys/action.yml
@@ -1,0 +1,47 @@
+---
+
+outputs:
+  cache-key-for-dep-files:
+    description: >-
+      A cache key string derived from the dependency declaration files.
+    value: ${{ steps.calc-cache-key-files.outputs.files-hash-key }}
+
+runs:
+  using: composite
+  steps:
+  - name: >-
+      Calculate dependency files' combined hash value
+      for use in the cache key
+    id: calc-cache-key-files
+    run: |
+      from os import environ
+      from pathlib import Path
+
+      FILE_APPEND_MODE = 'a'
+
+      files_derived_hash = '${{
+          hashFiles(
+            'setup.cfg',
+            'tox.ini',
+            'pyproject.toml',
+            '.pre-commit-config.yaml',
+            'pytest.ini',
+            'dependencies/**',
+            'dependencies/*/**',
+            'requirements-build.*',
+            'docs/requirements.*'
+          )
+      }}'
+
+      print(f'Computed file-derived hash is {files_derived_hash}.')
+
+      with Path(environ['GITHUB_OUTPUT']).open(
+              mode=FILE_APPEND_MODE,
+      ) as outputs_file:
+          print(
+              f'files-hash-key={files_derived_hash}',
+              file=outputs_file,
+          )
+    shell: python
+
+...

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -113,9 +113,6 @@ run-name: >-
   }})
 
 jobs:
-  lint:
-    uses: ./.github/workflows/reusable-linters.yml
-
   pre-setup:
     name: ⚙️ Pre-set global build settings
 
@@ -153,8 +150,8 @@ jobs:
         }}
       profiling-enabled: >-
         ${{ steps.profiling-check.outputs.profiling-enabled || false }}
-      cache-key-files: >-
-        ${{ steps.calc-cache-key-files.outputs.files-hash-key }}
+      cache-key-for-dep-files: >-
+        ${{ steps.calc-cache-key-files.outputs.cache-key-for-dep-files }}
       git-tag: ${{ steps.git-tag.outputs.tag }}
       sdist-artifact-name: ${{ steps.artifact-name.outputs.sdist }}
       wheel-artifact-name: ${{ steps.artifact-name.outputs.wheel }}
@@ -226,73 +223,19 @@ jobs:
           }}
         ref: ${{ github.event.inputs.release-committish }}
     - name: >-
-        Calculate Python interpreter version hash value
-        for use in the cache key
-      if: >-
-        steps.request-check.outputs.release-requested != 'true'
-      id: calc-cache-key-py
-      run: |
-        from hashlib import sha512
-        from os import environ
-        from pathlib import Path
-        from sys import version
-
-        FILE_APPEND_MODE = 'a'
-
-        hash = sha512(version.encode()).hexdigest()
-
-        with Path(environ['GITHUB_OUTPUT']).open(
-                mode=FILE_APPEND_MODE,
-        ) as outputs_file:
-            print(f'py-hash-key={hash}', file=outputs_file)
-    - name: >-
         Calculate dependency files' combined hash value
         for use in the cache key
       if: >-
         steps.request-check.outputs.release-requested != 'true'
       id: calc-cache-key-files
-      run: |
-        from hashlib import sha512
-        from os import environ
-        from pathlib import Path
-
-        FILE_APPEND_MODE = 'a'
-
-        hashes_combo = sha512('-'.join((
-          "${{ hashFiles('setup.cfg') }}",
-          "${{ hashFiles('tox.ini')}}",
-          "${{ hashFiles('pyproject.toml') }}",
-          "${{ hashFiles('.pre-commit-config.yaml') }}",
-          "${{ hashFiles('pytest.ini') }}",
-          "${{ hashFiles('requirements-build.*') }}",
-          "${{ hashFiles('docs/requirements.*') }}",
-        )).encode()).hexdigest()
-
-        with Path(environ['GITHUB_OUTPUT']).open(
-                mode=FILE_APPEND_MODE,
-        ) as outputs_file:
-            print(f"files-hash-key={hashes_combo}", file=outputs_file)
+      uses: ./.github/actions/cache-keys
     - name: Set up pip cache
       if: >-
         steps.request-check.outputs.release-requested != 'true'
-      uses: actions/cache@v4
+      uses: re-actors/cache-python-deps@release/v1
       with:
-        path: >-
-          ${{
-              runner.os == 'Linux'
-              && '~/.cache/pip'
-              || '~/Library/Caches/pip'
-          }}
-        key: >-
-          ${{ runner.os }}-pip-${{
-          steps.calc-cache-key-py.outputs.py-hash-key }}-${{
-          steps.calc-cache-key-files.outputs.files-hash-key }}
-        restore-keys: |
-          ${{ runner.os }}-pip-${{
-            steps.calc-cache-key-py.outputs.py-hash-key
-          }}-
-          ${{ runner.os }}-pip-
-          ${{ runner.os }}-
+        cache-key-for-dependency-files: >-
+          ${{ steps.calc-cache-key-files.outputs.cache-key-for-dep-files }}
     - name: Drop Git tags from HEAD for non-release requests
       if: >-
         steps.request-check.outputs.release-requested != 'true'
@@ -415,6 +358,13 @@ jobs:
                 || steps.scm-version.outputs.dist-version-for-filenames
             }}', file=outputs_file)
 
+  lint:
+    needs:
+    - pre-setup  # transitive, for accessing settings
+    uses: ./.github/workflows/reusable-linters.yml
+    with:
+      cache-key-files: ${{ needs.pre-setup.outputs.cache-key-for-dep-files }}
+
   build-changelog:
     name: >-
       👷📝 ${{ needs.pre-setup.outputs.git-tag }} changelog
@@ -480,44 +430,11 @@ jobs:
         fetch-depth: 1  # Enough for this job to generate the changelog
         ref: ${{ github.event.inputs.release-committish }}
 
-    - name: >-
-        Calculate Python interpreter version hash value
-        for use in the cache key
-      id: calc-cache-key-py
-      run: |
-        from hashlib import sha512
-        from os import environ
-        from pathlib import Path
-        from sys import version
-
-        FILE_APPEND_MODE = 'a'
-
-        hash = sha512(version.encode()).hexdigest()
-
-        with Path(environ['GITHUB_OUTPUT']).open(
-                mode=FILE_APPEND_MODE,
-        ) as outputs_file:
-            print(f'py-hash-key={hash}', file=outputs_file)
-      shell: python
     - name: Set up pip cache
-      uses: actions/cache@v4
+      uses: re-actors/cache-python-deps@release/v1
       with:
-        path: >-
-          ${{
-              runner.os == 'Linux'
-              && '~/.cache/pip'
-              || '~/Library/Caches/pip'
-          }}
-        key: >-
-          ${{ runner.os }}-pip-${{
-          steps.calc-cache-key-py.outputs.py-hash-key }}-${{
-          needs.pre-setup.outputs.cache-key-files }}
-        restore-keys: |
-          ${{ runner.os }}-pip-${{
-            steps.calc-cache-key-py.outputs.py-hash-key
-          }}-
-          ${{ runner.os }}-pip-
-          ${{ runner.os }}-
+        cache-key-for-dependency-files: >-
+          ${{ needs.pre-setup.outputs.cache-key-for-dep-files }}
     - name: Install tox
       run: >-
         python -m
@@ -871,44 +788,11 @@ jobs:
         git update-index --assume-unchanged $(git ls-files --modified)
       shell: bash
 
-    - name: >-
-        Calculate Python interpreter version hash value
-        for use in the cache key
-      id: calc-cache-key-py
-      run: |
-        from hashlib import sha512
-        from os import environ
-        from pathlib import Path
-        from sys import version
-
-        FILE_APPEND_MODE = 'a'
-
-        hash = sha512(version.encode()).hexdigest()
-
-        with Path(environ['GITHUB_OUTPUT']).open(
-                mode=FILE_APPEND_MODE,
-        ) as outputs_file:
-            print(f'py-hash-key={hash}', file=outputs_file)
-      shell: python
     - name: Set up pip cache
-      uses: actions/cache@v4
+      uses: re-actors/cache-python-deps@release/v1
       with:
-        path: >-
-          ${{
-              runner.os == 'Linux'
-              && '~/.cache/pip'
-              || '~/Library/Caches/pip'
-          }}
-        key: >-
-          ${{ runner.os }}-pip-${{
-          steps.calc-cache-key-py.outputs.py-hash-key }}-${{
-          needs.pre-setup.outputs.cache-key-files }}
-        restore-keys: |
-          ${{ runner.os }}-pip-${{
-            steps.calc-cache-key-py.outputs.py-hash-key
-          }}-
-          ${{ runner.os }}-pip-
-          ${{ runner.os }}-
+        cache-key-for-dependency-files: >-
+          ${{ needs.pre-setup.outputs.cache-key-for-dep-files }}
     - name: Install tox
       run: >-
         python -m
@@ -1255,7 +1139,7 @@ jobs:
       release-requested: >-
         ${{ needs.pre-setup.outputs.release-requested }}
       yolo: ${{ fromJSON(needs.pre-setup.outputs.is-yolo-mode) }}
-      cache-key-files: ${{ needs.pre-setup.outputs.cache-key-files }}
+      cache-key-files: ${{ needs.pre-setup.outputs.cache-key-for-dep-files }}
       source-tarball-name: >-
         ${{ needs.pre-setup.outputs.sdist-artifact-name }}
       dists-artifact-name: >-
@@ -1290,7 +1174,7 @@ jobs:
       release-requested: >-
         ${{ needs.pre-setup.outputs.release-requested }}
       yolo: ${{ fromJSON(needs.pre-setup.outputs.is-yolo-mode) }}
-      cache-key-files: ${{ needs.pre-setup.outputs.cache-key-files }}
+      cache-key-files: ${{ needs.pre-setup.outputs.cache-key-for-dep-files }}
       source-tarball-name: >-
         ${{ needs.pre-setup.outputs.sdist-artifact-name }}
       dists-artifact-name: >-
@@ -1326,44 +1210,11 @@ jobs:
         workflow-artifact-name: >-
           ${{ needs.pre-setup.outputs.dists-artifact-name }}
 
-    - name: >-
-        Calculate Python interpreter version hash value
-        for use in the cache key
-      id: calc-cache-key-py
-      run: |
-        from hashlib import sha512
-        from os import environ
-        from pathlib import Path
-        from sys import version
-
-        FILE_APPEND_MODE = 'a'
-
-        hash = sha512(version.encode()).hexdigest()
-
-        with Path(environ['GITHUB_OUTPUT']).open(
-                mode=FILE_APPEND_MODE,
-        ) as outputs_file:
-            print(f'py-hash-key={hash}', file=outputs_file)
-      shell: python
     - name: Set up pip cache
-      uses: actions/cache@v4
+      uses: re-actors/cache-python-deps@release/v1
       with:
-        path: >-
-          ${{
-              runner.os == 'Linux'
-              && '~/.cache/pip'
-              || '~/Library/Caches/pip'
-          }}
-        key: >-
-          ${{ runner.os }}-pip-${{
-          steps.calc-cache-key-py.outputs.py-hash-key }}-${{
-          needs.pre-setup.outputs.cache-key-files }}
-        restore-keys: |
-          ${{ runner.os }}-pip-${{
-            steps.calc-cache-key-py.outputs.py-hash-key
-          }}-
-          ${{ runner.os }}-pip-
-          ${{ runner.os }}-
+        cache-key-for-dependency-files: >-
+          ${{ needs.pre-setup.outputs.cache-key-for-dep-files }}
     - name: Install tox
       run: >-
         python -m
@@ -1830,44 +1681,11 @@ jobs:
       uses: actions/setup-python@v5.3.0
       with:
         python-version: 3.11
-    - name: >-
-        Calculate Python interpreter version hash value
-        for use in the cache key
-      id: calc-cache-key-py
-      run: |
-        from hashlib import sha512
-        from os import environ
-        from pathlib import Path
-        from sys import version
-
-        FILE_APPEND_MODE = 'a'
-
-        hash = sha512(version.encode()).hexdigest()
-
-        with Path(environ['GITHUB_OUTPUT']).open(
-                mode=FILE_APPEND_MODE,
-        ) as outputs_file:
-            print(f'py-hash-key={hash}', file=outputs_file)
-      shell: python
     - name: Set up pip cache
-      uses: actions/cache@v4
+      uses: re-actors/cache-python-deps@release/v1
       with:
-        path: >-
-          ${{
-              runner.os == 'Linux'
-              && '~/.cache/pip'
-              || '~/Library/Caches/pip'
-          }}
-        key: >-
-          ${{ runner.os }}-pip-${{
-          steps.calc-cache-key-py.outputs.py-hash-key }}-${{
-          needs.pre-setup.outputs.cache-key-files }}
-        restore-keys: |
-          ${{ runner.os }}-pip-${{
-            steps.calc-cache-key-py.outputs.py-hash-key
-          }}-
-          ${{ runner.os }}-pip-
-          ${{ runner.os }}-
+        cache-key-for-dependency-files: >-
+          ${{ needs.pre-setup.outputs.cache-key-for-dep-files }}
     - name: Install dumb-pypi dist from PyPI
       run: python -m pip install dumb-pypi --user
     - name: Generate a dumb PyPI website

--- a/.github/workflows/reusable-linters.yml
+++ b/.github/workflows/reusable-linters.yml
@@ -4,6 +4,11 @@ name: ♲ 🚨
 
 on:  # yamllint disable-line rule:truthy
   workflow_call:
+    inputs:
+      cache-key-files:
+        description: Dependency files cache
+        required: true
+        type: string
 
 env:
   TOX_VERSION: tox
@@ -39,50 +44,11 @@ jobs:
       uses: actions/setup-python@v5.3.0
       with:
         python-version: ${{ matrix.python-version }}
-    - name: >-
-        Calculate Python interpreter version hash value
-        for use in the cache key
-      id: calc-cache-key-py
-      run: |
-        from hashlib import sha512
-        from os import environ
-        from pathlib import Path
-        from sys import version
-
-        FILE_APPEND_MODE = 'a'
-
-        hash = sha512(version.encode()).hexdigest()
-
-        with Path(environ['GITHUB_OUTPUT']).open(
-                mode=FILE_APPEND_MODE,
-        ) as outputs_file:
-            print(f'py-hash-key={hash}', file=outputs_file)
-      shell: python
-    - name: Pre-commit cache
-      uses: actions/cache@v4
+    - name: Set up pip cache
+      uses: re-actors/cache-python-deps@release/v1
       with:
-        path: ~/.cache/pre-commit
-        key: >-
-          ${{ runner.os }}-pre-commit-${{
-          steps.calc-cache-key-py.outputs.py-hash-key }}-${{
-          hashFiles('setup.cfg') }}-${{ hashFiles('tox.ini') }}-${{
-          hashFiles('pyproject.toml') }}-${{
-          hashFiles('.pre-commit-config.yaml') }}-${{
-          hashFiles('pytest.ini') }}
-    - name: Pip cache
-      uses: actions/cache@v4
-      with:
-        path: ~/.cache/pip
-        key: >-
-          ${{ runner.os }}-pip-${{
-          steps.calc-cache-key-py.outputs.py-hash-key }}-${{
-          hashFiles('setup.cfg') }}-${{ hashFiles('tox.ini') }}-${{
-          hashFiles('pyproject.toml') }}-${{
-          hashFiles('.pre-commit-config.yaml') }}-${{
-          hashFiles('pytest.ini') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-          ${{ runner.os }}-
+        cache-key-for-dependency-files: >-
+          ${{ inputs.cache-key-files }}
     - name: Install tox
       run: >-
         python -m

--- a/.github/workflows/reusable-tests.yml
+++ b/.github/workflows/reusable-tests.yml
@@ -141,66 +141,11 @@ jobs:
         source-tarball-name: ${{ inputs.source-tarball-name }}
         workflow-artifact-name: ${{ inputs.dists-artifact-name }}
 
-    - name: Figure out if the interpreter ABI is stable
-      id: py-abi
-      run: |
-        from os import environ
-        from pathlib import Path
-        from sys import version_info
-
-        FILE_APPEND_MODE = 'a'
-
-        is_stable_abi = version_info.releaselevel == 'final'
-
-        with Path(environ['GITHUB_OUTPUT']).open(
-                mode=FILE_APPEND_MODE,
-        ) as outputs_file:
-            print(
-                'is-stable-abi={is_stable_abi}'.
-                format(is_stable_abi=str(is_stable_abi).lower()),
-                file=outputs_file,
-            )
-      shell: python
-    - name: >-
-        Calculate Python interpreter version hash value
-        for use in the cache key
-      if: fromJSON(steps.py-abi.outputs.is-stable-abi)
-      id: calc-cache-key-py
-      run: |
-        from hashlib import sha512
-        from os import environ
-        from pathlib import Path
-        from sys import version
-
-        FILE_APPEND_MODE = 'a'
-
-        hash = sha512(version.encode()).hexdigest()
-
-        with Path(environ['GITHUB_OUTPUT']).open(
-                mode=FILE_APPEND_MODE,
-        ) as outputs_file:
-            print(f'py-hash-key={hash}', file=outputs_file)
-      shell: python
     - name: Set up pip cache
-      if: fromJSON(steps.py-abi.outputs.is-stable-abi)
-      uses: actions/cache@v4
+      uses: re-actors/cache-python-deps@release/v1
       with:
-        path: >-
-          ${{
-              runner.os == 'Linux'
-              && '~/.cache/pip'
-              || '~/Library/Caches/pip'
-          }}
-        key: >-
-          ${{ runner.os }}-pip-${{
-          steps.calc-cache-key-py.outputs.py-hash-key }}-${{
-          inputs.cache-key-files }}
-        restore-keys: |
-          ${{ runner.os }}-pip-${{
-            steps.calc-cache-key-py.outputs.py-hash-key
-          }}-
-          ${{ runner.os }}-pip-
-          ${{ runner.os }}-
+        cache-key-for-dependency-files: >-
+          ${{ inputs.cache-key-files }}
 
     - name: Upgrade pip with `requires_python`
       run: >-


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This is a better Python pre-release aware caching for pip cache.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request