### PR TITLE
📦Only enable line tracing when w/Cython tracing

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -149,8 +149,7 @@ jobs:
           )
           && true || false
         }}
-      profiling-enabled: >-
-        ${{ steps.profiling-check.outputs.profiling-enabled || false }}
+      profiling-enabled: false
       cache-key-for-dep-files: >-
         ${{ steps.calc-cache-key-files.outputs.cache-key-for-dep-files }}
       git-tag: ${{ steps.git-tag.outputs.tag }}

--- a/docs/changelog-fragments/778.packaging.rst
+++ b/docs/changelog-fragments/778.packaging.rst
@@ -1,0 +1,18 @@
+The build backend now dynamically enables Cython line tracing only when
+explicitly requested via the ``with-cython-tracing=true`` config setting.
+Previously, having ``linetrace = "True"`` in :file:`pyproject.toml` was
+making our PyPI-published wheels slower due to debug symbols.
+
+Now, line tracing is truly opt-in:
+
+- Regular builds: ``pip install .`` (no line tracing)
+- Tracing builds:
+  ``pip install . --config-setting=with-cython-tracing=true``
+
+  (enables line tracing)
+
+When tracing is requested, the build backend automatically adds the
+``linetrace=True`` and ``profile=True`` Cython directives and sets the
+appropriate C compiler flags.
+
+-- by :user:`webknjaz`

--- a/packaging/pep517_backend/_backend.py
+++ b/packaging/pep517_backend/_backend.py
@@ -261,6 +261,7 @@ def _prebuild_c_extensions(
 
         cythonize_args = _make_cythonize_cli_args_from_config(
             config,
+            cython_line_tracing_requested=cython_line_tracing_requested,
         )
         with _patched_cython_env(
             config['env'],

--- a/packaging/pep517_backend/_cython_configuration.py
+++ b/packaging/pep517_backend/_cython_configuration.py
@@ -144,14 +144,37 @@ def get_local_cythonize_config() -> Config:
     return config_mapping['tool']['local']['cythonize']  # type: ignore[no-any-return]
 
 
+def _configure_cython_line_tracing(
+    config_kwargs: dict[str, str | dict[str, str]],
+    *,
+    cython_line_tracing_requested: bool,
+) -> None:
+    """Configure Cython line tracing directives if requested."""
+    # If line tracing is requested, add it to the directives
+    if cython_line_tracing_requested:
+        directives = config_kwargs.setdefault('directive', {})
+        assert isinstance(directives, dict)  # noqa: S101  # typing
+        directives['linetrace'] = 'True'
+        directives['profile'] = 'True'
+
+
 def make_cythonize_cli_args_from_config(
     config: Config,
+    *,
+    cython_line_tracing_requested: bool = False,
 ) -> list[str]:
     """Compose ``cythonize`` CLI args from config."""
     py_ver_arg = f'-{_python_version_tuple.major!s}'
 
     cli_flags = get_enabled_cli_flags_from_config(config['flags'])
-    cli_kwargs = get_cli_kwargs_from_config(config['kwargs'])
+    config_kwargs = config['kwargs']
+
+    _configure_cython_line_tracing(
+        config_kwargs,
+        cython_line_tracing_requested=cython_line_tracing_requested,
+    )
+
+    cli_kwargs = get_cli_kwargs_from_config(config_kwargs)
 
     return cli_flags + [py_ver_arg] + cli_kwargs + ['--'] + config['src']
 

--- a/packaging/pep517_backend/_transformers.py
+++ b/packaging/pep517_backend/_transformers.py
@@ -25,7 +25,7 @@ def _emit_opt_pairs(
         yield '='.join(map(str, (flag_opt, *pair)))
 
 
-def get_cli_kwargs_from_config(
+def get_cli_kwargs_from_config(  # noqa: WPS234
     kwargs_map: dict[str, str | dict[str, str]],
 ) -> list[str]:
     """Make a list of options with values from config."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,8 +113,6 @@ parallel = 1
 # Ref: https://github.com/cython/cython/blob/d6e6de9/Cython/Compiler/Options.py#L170-L242
 embedsignature = "True"
 emit_code_comments = "True"
-linetrace = "True"
-profile = "True"
 
 [tool.local.cythonize.kwargs.compile-time-env]
 # This section can contain compile time env vars


### PR DESCRIPTION
This patch modifies the build backend to dynamically enable Cython line tracing only when explicitly requested via the `with-cython-tracing=true` config setting. Previously, having `linetrace = "True"` in `pyproject.toml` was making our PyPI-published wheels slower.

Now, line tracing is opt-in:
- Regular builds: `pip install .` (no line tracing)
- Tracing builds: `pip install . --config-setting=with-cython-tracing=true`

  (enables line tracing)

When tracing is requested, the build backend automatically adds the `linetrace=True` and `profile=True` Cython directives and sets the appropriate C compiler flags.

Resolves #767

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Packaging Pull Request

##### BLOCKERS

* [ ] **Revert f8121c5**
* [ ] #729