### PR TITLE
🧪 Narrow SSH command in test helpers to one key

### DIFF
--- a/docs/changelog-fragments/782.contrib.rst
+++ b/docs/changelog-fragments/782.contrib.rst
@@ -1,0 +1,4 @@
+The SSHD start probe client command is now shielded from external
+environmnent and will no longer attempt using an SSH agent on the
+machine where the tests are involved, nor will it use alternative
+authentication methods -- by :user:`webknjaz`.

--- a/tests/_service_utils.py
+++ b/tests/_service_utils.py
@@ -44,11 +44,17 @@ def wait_for_svc_ready_state(
     """
     cmd = [
         '/usr/bin/ssh',
-        f'-l{getpass.getuser()!s}',
-        f'-i{clientkey_path!s}',
-        f'-p{port!s}',
-        '-oUserKnownHostsFile=/dev/null',
+        '-F/dev/null',  # or -Fnone
+        '-oConnectTimeout=1',
+        '-oIdentitiesOnly=yes',
+        '-oIdentityAgent=/dev/null',
+        f'-oIdentityFile={clientkey_path!s}',
+        '-oPasswordAuthentication=no',
+        f'-oPort={port!s}',
+        '-oPreferredAuthentications=publickey',
         '-oStrictHostKeyChecking=no',
+        f'-oUser={getpass.getuser()!s}',
+        '-oUserKnownHostsFile=/dev/null',
         host,
         '--',
         'exit 0',


### PR DESCRIPTION
Previously, `ssh` invocations would pick up `$SSH_AUTH_SOCK` and might hang if the agent (like Bitwarden) is awaiting for user input.

This patch improves the sshd probe helper responsiveness by disallowing the use of SSH agent, passwords, setting no config and setting a one-second timeout. The command is now narrowly scoped to only use the identity file passed via commandline explicitly.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
N/A