### PR TITLE
ci(macos): add workflow to build universal2 OpenSSL + libssh from source

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1219,6 +1219,7 @@ jobs:
     name: 🧪 Test${{ '' }}  # nest jobs under the same sidebar category
     needs:
     - build-bin-macos
+    - macos-merge-universal
     - build-src
     - pre-setup  # transitive, for accessing settings
     strategy:
@@ -1251,6 +1252,9 @@ jobs:
         ${{ needs.pre-setup.outputs.sdist-artifact-name }}
       dists-artifact-name: >-
         ${{ needs.pre-setup.outputs.dists-artifact-name }}
+      macos-universal-artifact-name: macos-universal2-artifacts
+      openssl-lib-name: openssl
+      libssh-lib-name: libssh
     secrets:
       codecov-token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/macos-universal.yml
+++ b/.github/workflows/macos-universal.yml
@@ -1,0 +1,207 @@
+name: macOS universal OpenSSL+libssh
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ devel ]
+  pull_request:
+
+env:
+  OPENSSL_VER: "3.1.4"
+  LIBSSH_VER: "0.11.2"
+
+jobs:
+  macos-arm64-build:
+    name: Build (arm64)
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Prep dirs
+        run: |
+          mkdir -p build arm64
+          echo "ROOT=$PWD" >> $GITHUB_ENV
+
+      - name: Build OpenSSL (arm64)
+        run: |
+          set -euxo pipefail
+          cd build
+          curl -LO "https://www.openssl.org/source/openssl-${OPENSSL_VER}.tar.gz"
+          tar xzf "openssl-${OPENSSL_VER}.tar.gz"
+          cd "openssl-${OPENSSL_VER}"
+          ./Configure darwin64-arm64-cc --prefix="$GITHUB_WORKSPACE/arm64/openssl" --libdir=lib \
+            no-tests no-ssl3 no-weak-ssl-ciphers enable-ec_nistp_64_gcc_128
+          make -j"$(sysctl -n hw.ncpu)"
+          make install_sw
+          file "$GITHUB_WORKSPACE/arm64/openssl/lib/libssl.dylib"
+
+      - name: Build libssh (arm64)
+        run: |
+          set -euxo pipefail
+          brew install cmake zlib || true
+          cd build
+          curl -LO "https://www.libssh.org/files/0.11/libssh-${LIBSSH_VER}.tar.xz"
+          tar xJf "libssh-${LIBSSH_VER}.tar.xz"
+          mkdir -p "libssh-${LIBSSH_VER}/build-arm64"
+          cd "libssh-${LIBSSH_VER}/build-arm64"
+          cmake .. \
+            -DCMAKE_BUILD_TYPE=MinSizeRel \
+            -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/arm64/libssh" \
+            -DCMAKE_OSX_ARCHITECTURES="arm64" \
+            -DBUILD_SHARED_LIBS=ON \
+            -DUNIT_TESTING=OFF -DCLIENT_TESTING=OFF -DSERVER_TESTING=OFF \
+            -DWITH_EXAMPLES=OFF -DWITH_GSSAPI=ON -DWITH_SERVER=OFF -DWITH_PCAP=OFF -DWITH_ZLIB=ON \
+            -DOPENSSL_ROOT_DIR="$GITHUB_WORKSPACE/arm64/openssl" \
+            -DOPENSSL_INCLUDE_DIR="$GITHUB_WORKSPACE/arm64/openssl/include" \
+            -DOPENSSL_CRYPTO_LIBRARY="$GITHUB_WORKSPACE/arm64/openssl/lib/libcrypto.dylib" \
+            -DOPENSSL_SSL_LIBRARY="$GITHUB_WORKSPACE/arm64/openssl/lib/libssl.dylib"
+          make -j"$(sysctl -n hw.ncpu)"
+          make install/strip
+          file "$GITHUB_WORKSPACE/arm64/libssh/lib/libssh.dylib"
+
+      - name: Package artifacts (arm64)
+        run: |
+          set -euxo pipefail
+          cd "$GITHUB_WORKSPACE/arm64"
+          tar czf "$GITHUB_WORKSPACE/openssl-${{ env.OPENSSL_VER }}-arm64.tgz" openssl
+          tar czf "$GITHUB_WORKSPACE/libssh-${{ env.LIBSSH_VER }}-arm64.tgz" libssh
+
+      - name: Upload artifacts (arm64)
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-arm64-artifacts
+          path: |
+            openssl-${{ env.OPENSSL_VER }}-arm64.tgz
+            libssh-${{ env.LIBSSH_VER }}-arm64.tgz
+          if-no-files-found: error
+
+  macos-x86_64-build:
+    name: Build (x86_64)
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Prep dirs
+        run: |
+          mkdir -p build x86_64
+
+      - name: Build OpenSSL (x86_64)
+        run: |
+          set -euxo pipefail
+          cd build
+          curl -LO "https://www.openssl.org/source/openssl-${OPENSSL_VER}.tar.gz"
+          tar xzf "openssl-${OPENSSL_VER}.tar.gz"
+          cd "openssl-${OPENSSL_VER}"
+          ./Configure darwin64-x86_64-cc --prefix="$GITHUB_WORKSPACE/x86_64/openssl" --libdir=lib \
+            no-tests no-ssl3 no-weak-ssl-ciphers enable-ec_nistp_64_gcc_128
+          make -j"$(sysctl -n hw.ncpu)"
+          make install_sw
+          file "$GITHUB_WORKSPACE/x86_64/openssl/lib/libssl.dylib"
+
+      - name: Build libssh (x86_64)
+        run: |
+          set -euxo pipefail
+          brew install cmake zlib || true
+          cd build
+          curl -LO "https://www.libssh.org/files/0.11/libssh-${LIBSSH_VER}.tar.xz"
+          tar xJf "libssh-${LIBSSH_VER}.tar.xz"
+          mkdir -p "libssh-${LIBSSH_VER}/build-x86_64"
+          cd "libssh-${LIBSSH_VER}/build-x86_64"
+          cmake .. \
+            -DCMAKE_BUILD_TYPE=MinSizeRel \
+            -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/x86_64/libssh" \
+            -DCMAKE_OSX_ARCHITECTURES="x86_64" \
+            -DBUILD_SHARED_LIBS=ON \
+            -DUNIT_TESTING=OFF -DCLIENT_TESTING=OFF -DSERVER_TESTING=OFF \
+            -DWITH_EXAMPLES=OFF -DWITH_GSSAPI=ON -DWITH_SERVER=OFF -DWITH_PCAP=OFF -DWITH_ZLIB=ON \
+            -DOPENSSL_ROOT_DIR="$GITHUB_WORKSPACE/x86_64/openssl" \
+            -DOPENSSL_INCLUDE_DIR="$GITHUB_WORKSPACE/x86_64/openssl/include" \
+            -DOPENSSL_CRYPTO_LIBRARY="$GITHUB_WORKSPACE/x86_64/openssl/lib/libcrypto.dylib" \
+            -DOPENSSL_SSL_LIBRARY="$GITHUB_WORKSPACE/x86_64/openssl/lib/libssl.dylib"
+          make -j"$(sysctl -n hw.ncpu)"
+          make install/strip
+          file "$GITHUB_WORKSPACE/x86_64/libssh/lib/libssh.dylib"
+
+      - name: Package artifacts (x86_64)
+        run: |
+          set -euxo pipefail
+          cd "$GITHUB_WORKSPACE/x86_64"
+          tar czf "$GITHUB_WORKSPACE/openssl-${{ env.OPENSSL_VER }}-x86_64.tgz" openssl
+          tar czf "$GITHUB_WORKSPACE/libssh-${{ env.LIBSSH_VER }}-x86_64.tgz" libssh
+
+      - name: Upload artifacts (x86_64)
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-x86_64-artifacts
+          path: |
+            openssl-${{ env.OPENSSL_VER }}-x86_64.tgz
+            libssh-${{ env.LIBSSH_VER }}-x86_64.tgz
+          if-no-files-found: error
+
+  macos-merge-universal:
+    name: Merge → universal2
+    runs-on: macos-14
+    needs: [macos-arm64-build, macos-x86_64-build]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-arm64-artifacts
+          path: arm64
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: macos-x86_64-artifacts
+          path: x86_64
+
+      - name: Unpack
+        run: |
+          mkdir -p merge
+          tar xzf arm64/openssl-*-arm64.tgz -C merge
+          tar xzf arm64/libssh-*-arm64.tgz   -C merge
+          tar xzf x86_64/openssl-*-x86_64.tgz -C merge
+          tar xzf x86_64/libssh-*-x86_64.tgz  -C merge
+          ls -R merge
+
+      - name: Lipo → universal2
+        run: |
+          set -euxo pipefail
+          mkdir -p universal/openssl/lib universal/openssl/include universal/libssh/lib universal/libssh/include
+
+          cp -R merge/openssl/include/* universal/openssl/include/
+          cp -R merge/libssh/include/*   universal/libssh/include/
+
+          lipo -create merge/openssl/lib/libssl.dylib   merge/x86_64/openssl/lib/libssl.dylib   -output universal/openssl/lib/libssl.dylib
+          lipo -create merge/openssl/lib/libcrypto.dylib merge/x86_64/openssl/lib/libcrypto.dylib -output universal/openssl/lib/libcrypto.dylib
+          lipo -create merge/libssh/lib/libssh.dylib     merge/x86_64/libssh/lib/libssh.dylib     -output universal/libssh/lib/libssh.dylib
+
+          # optional static libs if built:
+          if [ -f merge/openssl/lib/libssl.a ] && [ -f merge/x86_64/openssl/lib/libssl.a ]; then
+            lipo -create merge/openssl/lib/libssl.a merge/x86_64/openssl/lib/libssl.a -output universal/openssl/lib/libssl.a
+          fi
+          if [ -f merge/openssl/lib/libcrypto.a ] && [ -f merge/x86_64/openssl/lib/libcrypto.a ]; then
+            lipo -create merge/openssl/lib/libcrypto.a merge/x86_64/openssl/lib/libcrypto.a -output universal/openssl/lib/libcrypto.a
+          fi
+          if [ -f merge/libssh/lib/libssh.a ] && [ -f merge/x86_64/libssh/lib/libssh.a ]; then
+            lipo -create merge/libssh/lib/libssh.a merge/x86_64/libssh/lib/libssh.a -output universal/libssh/lib/libssh.a
+          fi
+
+          file universal/openssl/lib/libssl.dylib
+          lipo -info universal/openssl/lib/libssl.dylib
+          otool -L universal/libssh/lib/libssh.dylib
+
+      - name: Package universal artifacts
+        run: |
+          tar czf openssl-${{ env.OPENSSL_VER }}-universal2.tgz -C universal openssl
+          tar czf libssh-${{ env.LIBSSH_VER }}-universal2.tgz   -C universal libssh
+
+      - name: Upload universal artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-universal2-artifacts
+          path: |
+            openssl-${{ env.OPENSSL_VER }}-universal2.tgz
+            libssh-${{ env.LIBSSH_VER }}-universal2.tgz
+          if-no-files-found: error

--- a/.github/workflows/macos-universal.yml
+++ b/.github/workflows/macos-universal.yml
@@ -1,4 +1,4 @@
-name: macOS universal OpenSSL+libssh
+name: Multi-arch macOS OpenSSL and libssh artifacts
 
 on:
   workflow_dispatch:
@@ -9,62 +9,87 @@ on:
 env:
   OPENSSL_VER: "3.1.4"
   LIBSSH_VER: "0.11.2"
+  MACOSX_DEPLOYMENT_TARGET: "11.0"
 
 jobs:
   macos-arm64-build:
     name: Build (arm64)
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out source
+        uses: actions/checkout@v4
 
-      - name: Prep dirs
+      - name: Create staging directories
+        run: mkdir -pv build arm64
+
+      # --- OpenSSL (arm64) ---
+      - name: Download OpenSSL source
+        working-directory: build
+        run: curl -LO "https://www.openssl.org/source/openssl-${OPENSSL_VER}.tar.gz"
+
+      - name: Extract OpenSSL source
+        working-directory: build
+        run: tar xzf "openssl-${OPENSSL_VER}.tar.gz"
+
+      - name: Configure OpenSSL (arm64)
+        working-directory: build/openssl-${{ env.OPENSSL_VER }}
         run: |
-          mkdir -p build arm64
-          echo "ROOT=$PWD" >> $GITHUB_ENV
+          ./Configure darwin64-arm64-cc \
+            --prefix="$GITHUB_WORKSPACE/arm64/openssl" \
+            --libdir=lib \
+            no-tests no-ssl3 no-weak-ssl-ciphers enable-ec_nistp_64_gcc_128
 
       - name: Build OpenSSL (arm64)
-        run: |
-          set -euxo pipefail
-          cd build
-          curl -LO "https://www.openssl.org/source/openssl-${OPENSSL_VER}.tar.gz"
-          tar xzf "openssl-${OPENSSL_VER}.tar.gz"
-          cd "openssl-${OPENSSL_VER}"
-          ./Configure darwin64-arm64-cc --prefix="$GITHUB_WORKSPACE/arm64/openssl" --libdir=lib \
-            no-tests no-ssl3 no-weak-ssl-ciphers enable-ec_nistp_64_gcc_128
-          make -j"$(sysctl -n hw.ncpu)"
-          make install_sw
-          file "$GITHUB_WORKSPACE/arm64/openssl/lib/libssl.dylib"
+        working-directory: build/openssl-${{ env.OPENSSL_VER }}
+        run: make -j"$(sysctl -n hw.ncpu)"
 
-      - name: Build libssh (arm64)
+      - name: Install OpenSSL into staging (arm64)
+        working-directory: build/openssl-${{ env.OPENSSL_VER }}
+        run: make install_sw
+
+      - name: Inspect OpenSSL artifact (arm64)
+        run: file "$GITHUB_WORKSPACE/arm64/openssl/lib/libssl.dylib"
+
+      # --- libssh (arm64) ---
+      - name: Install build tools
+        run: brew install cmake zlib || true
+
+      - name: Download libssh source
+        working-directory: build
+        run: curl -LO "https://www.libssh.org/files/0.11/libssh-${LIBSSH_VER}.tar.xz"
+
+      - name: Extract libssh source
+        working-directory: build
+        run: tar xJf "libssh-${LIBSSH_VER}.tar.xz"
+
+      - name: Configure libssh (arm64)
+        working-directory: build/libssh-${{ env.LIBSSH_VER }}
         run: |
-          set -euxo pipefail
-          brew install cmake zlib || true
-          cd build
-          curl -LO "https://www.libssh.org/files/0.11/libssh-${LIBSSH_VER}.tar.xz"
-          tar xJf "libssh-${LIBSSH_VER}.tar.xz"
-          mkdir -p "libssh-${LIBSSH_VER}/build-arm64"
-          cd "libssh-${LIBSSH_VER}/build-arm64"
-          cmake .. \
+          cmake -S . -B build-arm64 \
             -DCMAKE_BUILD_TYPE=MinSizeRel \
             -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/arm64/libssh" \
             -DCMAKE_OSX_ARCHITECTURES="arm64" \
             -DBUILD_SHARED_LIBS=ON \
             -DUNIT_TESTING=OFF -DCLIENT_TESTING=OFF -DSERVER_TESTING=OFF \
             -DWITH_EXAMPLES=OFF -DWITH_GSSAPI=ON -DWITH_SERVER=OFF -DWITH_PCAP=OFF -DWITH_ZLIB=ON \
-            -DOPENSSL_ROOT_DIR="$GITHUB_WORKSPACE/arm64/openssl" \
-            -DOPENSSL_INCLUDE_DIR="$GITHUB_WORKSPACE/arm64/openssl/include" \
-            -DOPENSSL_CRYPTO_LIBRARY="$GITHUB_WORKSPACE/arm64/openssl/lib/libcrypto.dylib" \
-            -DOPENSSL_SSL_LIBRARY="$GITHUB_WORKSPACE/arm64/openssl/lib/libssl.dylib"
-          make -j"$(sysctl -n hw.ncpu)"
-          make install/strip
-          file "$GITHUB_WORKSPACE/arm64/libssh/lib/libssh.dylib"
+            -DOPENSSL_ROOT_DIR="$GITHUB_WORKSPACE/arm64/openssl"
 
-      - name: Package artifacts (arm64)
-        run: |
-          set -euxo pipefail
-          cd "$GITHUB_WORKSPACE/arm64"
-          tar czf "$GITHUB_WORKSPACE/openssl-${{ env.OPENSSL_VER }}-arm64.tgz" openssl
-          tar czf "$GITHUB_WORKSPACE/libssh-${{ env.LIBSSH_VER }}-arm64.tgz" libssh
+      - name: Build libssh (arm64)
+        working-directory: build/libssh-${{ env.LIBSSH_VER }}/build-arm64
+        run: make -j"$(sysctl -n hw.ncpu)"
+
+      - name: Install libssh into staging (arm64)
+        working-directory: build/libssh-${{ env.LIBSSH_VER }}/build-arm64
+        run: make install/strip
+
+      - name: Inspect libssh artifact (arm64)
+        run: file "$GITHUB_WORKSPACE/arm64/libssh/lib/libssh.dylib"
+
+      - name: Package OpenSSL (arm64)
+        run: tar czvf "$GITHUB_WORKSPACE/openssl-${{ env.OPENSSL_VER }}-arm64.tgz" -C "$GITHUB_WORKSPACE/arm64" openssl
+
+      - name: Package libssh (arm64)
+        run: tar czvf "$GITHUB_WORKSPACE/libssh-${{ env.LIBSSH_VER }}-arm64.tgz" -C "$GITHUB_WORKSPACE/arm64" libssh
 
       - name: Upload artifacts (arm64)
         uses: actions/upload-artifact@v4
@@ -77,57 +102,82 @@ jobs:
 
   macos-x86_64-build:
     name: Build (x86_64)
-    runs-on: macos-13
+    runs-on: macos-15-intel
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out source
+        uses: actions/checkout@v4
 
-      - name: Prep dirs
+      - name: Create staging directories
+        run: mkdir -pv build x86_64
+
+      # --- OpenSSL (x86_64) ---
+      - name: Download OpenSSL source
+        working-directory: build
+        run: curl -LO "https://www.openssl.org/source/openssl-${OPENSSL_VER}.tar.gz"
+
+      - name: Extract OpenSSL source
+        working-directory: build
+        run: tar xzf "openssl-${OPENSSL_VER}.tar.gz"
+
+      - name: Configure OpenSSL (x86_64)
+        working-directory: build/openssl-${{ env.OPENSSL_VER }}
         run: |
-          mkdir -p build x86_64
+          ./Configure darwin64-x86_64-cc \
+            --prefix="$GITHUB_WORKSPACE/x86_64/openssl" \
+            --libdir=lib \
+            no-tests no-ssl3 no-weak-ssl-ciphers enable-ec_nistp_64_gcc_128
 
       - name: Build OpenSSL (x86_64)
-        run: |
-          set -euxo pipefail
-          cd build
-          curl -LO "https://www.openssl.org/source/openssl-${OPENSSL_VER}.tar.gz"
-          tar xzf "openssl-${OPENSSL_VER}.tar.gz"
-          cd "openssl-${OPENSSL_VER}"
-          ./Configure darwin64-x86_64-cc --prefix="$GITHUB_WORKSPACE/x86_64/openssl" --libdir=lib \
-            no-tests no-ssl3 no-weak-ssl-ciphers enable-ec_nistp_64_gcc_128
-          make -j"$(sysctl -n hw.ncpu)"
-          make install_sw
-          file "$GITHUB_WORKSPACE/x86_64/openssl/lib/libssl.dylib"
+        working-directory: build/openssl-${{ env.OPENSSL_VER }}
+        run: make -j"$(sysctl -n hw.ncpu)"
 
-      - name: Build libssh (x86_64)
+      - name: Install OpenSSL into staging (x86_64)
+        working-directory: build/openssl-${{ env.OPENSSL_VER }}
+        run: make install_sw
+
+      - name: Inspect OpenSSL artifact (x86_64)
+        run: file "$GITHUB_WORKSPACE/x86_64/openssl/lib/libssl.dylib"
+
+      # --- libssh (x86_64) ---
+      - name: Install build tools
+        run: brew install cmake zlib || true
+
+      - name: Download libssh source
+        working-directory: build
+        run: curl -LO "https://www.libssh.org/files/0.11/libssh-${LIBSSH_VER}.tar.xz"
+
+      - name: Extract libssh source
+        working-directory: build
+        run: tar xJf "libssh-${LIBSSH_VER}.tar.xz"
+
+      - name: Configure libssh (x86_64)
+        working-directory: build/libssh-${{ env.LIBSSH_VER }}
         run: |
-          set -euxo pipefail
-          brew install cmake zlib || true
-          cd build
-          curl -LO "https://www.libssh.org/files/0.11/libssh-${LIBSSH_VER}.tar.xz"
-          tar xJf "libssh-${LIBSSH_VER}.tar.xz"
-          mkdir -p "libssh-${LIBSSH_VER}/build-x86_64"
-          cd "libssh-${LIBSSH_VER}/build-x86_64"
-          cmake .. \
+          cmake -S . -B build-x86_64 \
             -DCMAKE_BUILD_TYPE=MinSizeRel \
             -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/x86_64/libssh" \
             -DCMAKE_OSX_ARCHITECTURES="x86_64" \
             -DBUILD_SHARED_LIBS=ON \
             -DUNIT_TESTING=OFF -DCLIENT_TESTING=OFF -DSERVER_TESTING=OFF \
             -DWITH_EXAMPLES=OFF -DWITH_GSSAPI=ON -DWITH_SERVER=OFF -DWITH_PCAP=OFF -DWITH_ZLIB=ON \
-            -DOPENSSL_ROOT_DIR="$GITHUB_WORKSPACE/x86_64/openssl" \
-            -DOPENSSL_INCLUDE_DIR="$GITHUB_WORKSPACE/x86_64/openssl/include" \
-            -DOPENSSL_CRYPTO_LIBRARY="$GITHUB_WORKSPACE/x86_64/openssl/lib/libcrypto.dylib" \
-            -DOPENSSL_SSL_LIBRARY="$GITHUB_WORKSPACE/x86_64/openssl/lib/libssl.dylib"
-          make -j"$(sysctl -n hw.ncpu)"
-          make install/strip
-          file "$GITHUB_WORKSPACE/x86_64/libssh/lib/libssh.dylib"
+            -DOPENSSL_ROOT_DIR="$GITHUB_WORKSPACE/x86_64/openssl"
 
-      - name: Package artifacts (x86_64)
-        run: |
-          set -euxo pipefail
-          cd "$GITHUB_WORKSPACE/x86_64"
-          tar czf "$GITHUB_WORKSPACE/openssl-${{ env.OPENSSL_VER }}-x86_64.tgz" openssl
-          tar czf "$GITHUB_WORKSPACE/libssh-${{ env.LIBSSH_VER }}-x86_64.tgz" libssh
+      - name: Build libssh (x86_64)
+        working-directory: build/libssh-${{ env.LIBSSH_VER }}/build-x86_64
+        run: make -j"$(sysctl -n hw.ncpu)"
+
+      - name: Install libssh into staging (x86_64)
+        working-directory: build/libssh-${{ env.LIBSSH_VER }}/build-x86_64
+        run: make install/strip
+
+      - name: Inspect libssh artifact (x86_64)
+        run: file "$GITHUB_WORKSPACE/x86_64/libssh/lib/libssh.dylib"
+
+      - name: Package OpenSSL (x86_64)
+        run: tar czvf "$GITHUB_WORKSPACE/openssl-${{ env.OPENSSL_VER }}-x86_64.tgz" -C "$GITHUB_WORKSPACE/x86_64" openssl
+
+      - name: Package libssh (x86_64)
+        run: tar czvf "$GITHUB_WORKSPACE/libssh-${{ env.LIBSSH_VER }}-x86_64.tgz" -C "$GITHUB_WORKSPACE/x86_64" libssh
 
       - name: Upload artifacts (x86_64)
         uses: actions/upload-artifact@v4
@@ -140,62 +190,63 @@ jobs:
 
   macos-merge-universal:
     name: Merge → universal2
-    runs-on: macos-14
+    runs-on: macos-15
     needs: [macos-arm64-build, macos-x86_64-build]
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out source
+        uses: actions/checkout@v4
 
-      - name: Download artifacts
+      - name: Download per-arch artifacts (merged)
         uses: actions/download-artifact@v4
         with:
-          name: macos-arm64-artifacts
-          path: arm64
+          pattern: macos-*-artifacts
+          path: downloads
+          merge-multiple: true
 
-      - uses: actions/download-artifact@v4
-        with:
-          name: macos-x86_64-artifacts
-          path: x86_64
-
-      - name: Unpack
+      - name: Unpack per-arch artifacts into merge dirs
         run: |
-          mkdir -p merge
-          tar xzf arm64/openssl-*-arm64.tgz -C merge
-          tar xzf arm64/libssh-*-arm64.tgz   -C merge
-          tar xzf x86_64/openssl-*-x86_64.tgz -C merge
-          tar xzf x86_64/libssh-*-x86_64.tgz  -C merge
+          set -euxo pipefail
+          mkdir -p merge/arm64 merge/x86_64
+          tar xzf downloads/openssl-*-arm64.tgz   -C merge/arm64
+          tar xzf downloads/libssh-*-arm64.tgz    -C merge/arm64
+          tar xzf downloads/openssl-*-x86_64.tgz  -C merge/x86_64
+          tar xzf downloads/libssh-*-x86_64.tgz   -C merge/x86_64
           ls -R merge
 
-      - name: Lipo → universal2
+      - name: Lipo dylibs into universal2
         run: |
           set -euxo pipefail
           mkdir -p universal/openssl/lib universal/openssl/include universal/libssh/lib universal/libssh/include
 
-          cp -R merge/openssl/include/* universal/openssl/include/
-          cp -R merge/libssh/include/*   universal/libssh/include/
+          # headers (take from one arch — they are arch-agnostic)
+          cp -R merge/arm64/openssl/include/* universal/openssl/include/
+          cp -R merge/arm64/libssh/include/*   universal/libssh/include/
 
-          lipo -create merge/openssl/lib/libssl.dylib   merge/x86_64/openssl/lib/libssl.dylib   -output universal/openssl/lib/libssl.dylib
-          lipo -create merge/openssl/lib/libcrypto.dylib merge/x86_64/openssl/lib/libcrypto.dylib -output universal/openssl/lib/libcrypto.dylib
-          lipo -create merge/libssh/lib/libssh.dylib     merge/x86_64/libssh/lib/libssh.dylib     -output universal/libssh/lib/libssh.dylib
+          # merge shared libraries
+          lipo -create \
+            merge/arm64/openssl/lib/libssl.dylib \
+            merge/x86_64/openssl/lib/libssl.dylib \
+            -output universal/openssl/lib/libssl.dylib
 
-          # optional static libs if built:
-          if [ -f merge/openssl/lib/libssl.a ] && [ -f merge/x86_64/openssl/lib/libssl.a ]; then
-            lipo -create merge/openssl/lib/libssl.a merge/x86_64/openssl/lib/libssl.a -output universal/openssl/lib/libssl.a
-          fi
-          if [ -f merge/openssl/lib/libcrypto.a ] && [ -f merge/x86_64/openssl/lib/libcrypto.a ]; then
-            lipo -create merge/openssl/lib/libcrypto.a merge/x86_64/openssl/lib/libcrypto.a -output universal/openssl/lib/libcrypto.a
-          fi
-          if [ -f merge/libssh/lib/libssh.a ] && [ -f merge/x86_64/libssh/lib/libssh.a ]; then
-            lipo -create merge/libssh/lib/libssh.a merge/x86_64/libssh/lib/libssh.a -output universal/libssh/lib/libssh.a
-          fi
+          lipo -create \
+            merge/arm64/openssl/lib/libcrypto.dylib \
+            merge/x86_64/openssl/lib/libcrypto.dylib \
+            -output universal/openssl/lib/libcrypto.dylib
+
+          lipo -create \
+            merge/arm64/libssh/lib/libssh.dylib \
+            merge/x86_64/libssh/lib/libssh.dylib \
+            -output universal/libssh/lib/libssh.dylib
 
           file universal/openssl/lib/libssl.dylib
           lipo -info universal/openssl/lib/libssl.dylib
-          otool -L universal/libssh/lib/libssh.dylib
+          otool -L universal/libssh/lib/libssh.dylib || true
 
-      - name: Package universal artifacts
-        run: |
-          tar czf openssl-${{ env.OPENSSL_VER }}-universal2.tgz -C universal openssl
-          tar czf libssh-${{ env.LIBSSH_VER }}-universal2.tgz   -C universal libssh
+      - name: Package OpenSSL (universal2)
+        run: tar czvf openssl-${{ env.OPENSSL_VER }}-universal2.tgz -C universal openssl
+
+      - name: Package libssh (universal2)
+        run: tar czvf libssh-${{ env.LIBSSH_VER }}-universal2.tgz -C universal libssh
 
       - name: Upload universal artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/reusable-tests.yml
+++ b/.github/workflows/reusable-tests.yml
@@ -42,6 +42,20 @@ on:  # yamllint disable-line rule:truthy
         default: 'false'
         required: false
         type: string
+      macos-universal-artifact-name:
+        description: Name of artifact with universal2 OpenSSL+libssh (macOS)
+        required: false
+        type: string
+      openssl-lib-name:
+        description: Directory name for OpenSSL inside the artifact
+        required: false
+        type: string
+        default: openssl
+      libssh-lib-name:
+        description: Directory name for libssh inside the artifact
+        required: false
+        type: string
+        default: libssh
     secrets:
       codecov-token:
         description: Mandatory token for uploading to Codecov
@@ -127,10 +141,30 @@ jobs:
         inputs.dist-type == 'source' &&
         runner.os == 'Linux'
       run: sudo apt update && sudo apt install build-essential libssl-dev
-    - name: Install libssh and openssl headers on macOS
+    - name: (macOS) Download universal2 OpenSSL+libssh
       if: >-
-        runner.os == 'macOS'
-      run: brew install libssh
+        runner.os == 'macOS' && inputs.macos-universal-artifact-name != ''
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.macos-universal-artifact-name }}
+        path: .deps/
+    - name: (macOS) Unpack deps and export build env
+      if: >-
+        runner.os == 'macOS' && inputs.macos-universal-artifact-name != ''
+      run: |
+        set -euxo pipefail
+        mkdir -p .deps/u
+        tar xzf .deps/openssl-*-universal2.tgz -C .deps/u
+        tar xzf .deps/libssh-*-universal2.tgz  -C .deps/u
+        OPENSSL_DIR="$(pwd)/.deps/u/${{ inputs.openssl-lib-name }}"
+        LIBSSH_DIR="$(pwd)/.deps/u/${{ inputs.libssh-lib-name }}"
+        {
+          echo "OPENSSL_DIR=$OPENSSL_DIR"
+          echo "LIBSSH_DIR=$LIBSSH_DIR"
+          echo "PKG_CONFIG_PATH=$OPENSSL_DIR/lib/pkgconfig:$LIBSSH_DIR/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
+          echo "LDFLAGS=-L$OPENSSL_DIR/lib -L$LIBSSH_DIR/lib ${LDFLAGS:-}"
+          echo "CPPFLAGS=-I$OPENSSL_DIR/include -I$LIBSSH_DIR/include ${CPPFLAGS:-}"
+        } >> "$GITHUB_ENV"
     - name: Install catchsegv and libssh headers on Linux for cythonize+coverage
       if: >-
         runner.os == 'Linux'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR introduces a new GitHub Actions workflow, `macOS-universal.yaml` — that builds and packages OpenSSL and libssh from source on macOS, producing universal2 artifacts (for both arm64 and x86_64 architectures).
The goal is to replace the current `brew install libssh` dependency in CI and enable fully reproducible macOS builds of libssh and its dependencies.

ci(macos):  It builds OpenSSL + libssh per arch, uploads artifacts, then merges with lipo into universal2.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Refs: #699 #207 #73
Issues: [ACA-3946](https://issues.redhat.com/browse/ACA-3946)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request
- Packaging Pull Request


