### PR TITLE
Remove EOF Check

### DIFF
--- a/docs/changelog-fragments/785.bugfix.rst
+++ b/docs/changelog-fragments/785.bugfix.rst
@@ -1,0 +1,1 @@
+786.bugfix.rst

--- a/docs/changelog-fragments/786.bugfix.rst
+++ b/docs/changelog-fragments/786.bugfix.rst
@@ -1,2 +1,1 @@
-Improve compatibility with Cisco SCP servers when fetching files by avoiding a
-race condition on the EOF check -- by :user:`timway`.
+Removed non-mandatory EOF check after the SCP download procedure, which was causing race conditions with some Cisco devices -- by :user:`timway`.

--- a/docs/changelog-fragments/786.bugfix.rst
+++ b/docs/changelog-fragments/786.bugfix.rst
@@ -1,0 +1,2 @@
+Remove the SCP EOF message check in the ``get`` method to allow libssh clients
+get files from Cisco SCP servers. -- by :user:`timway`.

--- a/docs/changelog-fragments/786.bugfix.rst
+++ b/docs/changelog-fragments/786.bugfix.rst
@@ -1,2 +1,2 @@
-Remove the SCP EOF message check in the ``get`` method to allow libssh clients
-get files from Cisco SCP servers. -- by :user:`timway`.
+Improve compatibility with Cisco SCP servers when fetching files by avoiding a
+race condition on the EOF check -- by :user:`timway`.

--- a/src/pylibsshext/scp.pyx
+++ b/src/pylibsshext/scp.pyx
@@ -159,12 +159,6 @@ cdef class SCP:
                     remaining_bytes_to_read -= read_bytes
             if mode >= 0:
                 os.chmod(local_file, mode)
-
-            # Make sure we have finished requesting files
-            rc = libssh.ssh_scp_pull_request(scp)
-            if rc != libssh.SSH_SCP_REQUEST_EOF:
-                raise LibsshSCPException("Unexpected request: %s" % self._get_ssh_error_str())
-
         finally:
             if read_buffer is not NULL:
                 PyMem_Free(read_buffer)


### PR DESCRIPTION
##### SUMMARY

- Cisco SCP server will close the channel after retreiving a file and calling `ssh_scp_pull_request` will return `-1` and raise an exception aborting `get`

Fixes #785

##### ISSUE TYPE

- Bugfix Pull Request