### PR TITLE
Update macOS VMs in CI/CD to v15 on Intel arch

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -579,11 +579,11 @@ jobs:
     strategy:
       matrix:
         runner-vm-os:
-        - macos-13
+        - macos-15-intel
     uses: ./.github/workflows/reusable-cibuildwheel.yml
     with:
       runner-vm-os: ${{ matrix.runner-vm-os }}
-      timeout-minutes: 9
+      timeout-minutes: 10
       source-tarball-name: >-
         ${{ needs.pre-setup.outputs.sdist-artifact-name }}
       dists-artifact-name: >-
@@ -1168,7 +1168,7 @@ jobs:
         - "3.10"
         - 3.9
         runner-vm-os:
-        - macos-13
+        - macos-15-intel
         dist-type:
         - binary
         - source

--- a/docs/changelog-fragments/791.contrib.rst
+++ b/docs/changelog-fragments/791.contrib.rst
@@ -1,0 +1,2 @@
+Added "macos-15-intel" as vm runner as "macos-13" is not being supported anymore
+The change includes giving the macOS build job more time to complete as the new version is a little slower -- by :user:`komaldesai13`

--- a/docs/changelog-fragments/791.contrib.rst
+++ b/docs/changelog-fragments/791.contrib.rst
@@ -1,2 +1,3 @@
-Added "macos-15-intel" as vm runner as "macos-13" is not being supported anymore
-The change includes giving the macOS build job more time to complete as the new version is a little slower -- by :user:`komaldesai13`
+Now that the ``macos-13`` runner VM image has been decommissioned, the CI and CD jobs have been migrated to use ``macos-15-intel`` -- by :user:`komaldesai13`.
+
+This includes giving the macOS build job more time to complete as the new version is a little slower.


### PR DESCRIPTION
##### SUMMARY

CI run fails due to `macos-13` getting dropped by GitHub, this PR updates `runner-vm-os` to `macos-15-intel` to address that.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request