### PR TITLE
Update to libssh 0.12.0 in platform-specific wheels

### DIFF
--- a/docs/changelog-fragments/798.contrib.rst
+++ b/docs/changelog-fragments/798.contrib.rst
@@ -1,3 +1,2 @@
 Updated the bundled version of libssh to 0.12.0 in platform-specific
 wheels published on PyPI -- by :user:`Jakuje`.
-

--- a/docs/changelog-fragments/798.contrib.rst
+++ b/docs/changelog-fragments/798.contrib.rst
@@ -1,0 +1,3 @@
+Updated the bundled version of libssh to 0.12.0 in platform-specific
+wheels published on PyPI -- by :user:`Jakuje`.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,10 +220,10 @@ PRE_COMMIT_COLOR = "always"
 PY_COLORS = "1"
 
 [tool.cibuildwheel.linux]
-manylinux-aarch64-image = "ghcr.io/ansible/pylibssh-manylinux_2_28_aarch64:libssh-v0.11.3"
-manylinux-ppc64le-image = "ghcr.io/ansible/pylibssh-manylinux_2_28_ppc64le:libssh-v0.11.3"
-manylinux-s390x-image = "ghcr.io/ansible/pylibssh-manylinux_2_28_s390x:libssh-v0.11.3"
-manylinux-x86_64-image = "ghcr.io/ansible/pylibssh-manylinux_2_28_x86_64:libssh-v0.11.3"
+manylinux-aarch64-image = "ghcr.io/ansible/pylibssh-manylinux_2_28_aarch64:libssh-v0.12.0"
+manylinux-ppc64le-image = "ghcr.io/ansible/pylibssh-manylinux_2_28_ppc64le:libssh-v0.12.0"
+manylinux-s390x-image = "ghcr.io/ansible/pylibssh-manylinux_2_28_s390x:libssh-v0.12.0"
+manylinux-x86_64-image = "ghcr.io/ansible/pylibssh-manylinux_2_28_x86_64:libssh-v0.12.0"
 skip = [
   "*-musllinux_*",  # FIXME: musllinux needs us to provide with containers pre-built libssh
   "pp*",  # FIXME: we don't ship these currently but could


### PR DESCRIPTION
##### SUMMARY
Update to libssh 0.12.0 in platform-specific wheels

Follow-up from #797

##### ISSUE TYPE
- Bugfix Pull Request