### PR TITLE
Update build images to include recent ubi9 and current Fedora versions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -909,10 +909,9 @@ jobs:
     strategy:
       matrix:
         target-container:
-        - tag: fedora:39
-        - tag: fedora:40
-        - tag: fedora:41
         - tag: fedora:42
+        - tag: fedora:43
+        - tag: fedora:44
         - tag: ubi9/ubi:9.0.0
           registry: registry.access.redhat.com
         - tag: ubi9/ubi:9.1
@@ -922,6 +921,12 @@ jobs:
         - tag: ubi9/ubi:9.3
           registry: registry.access.redhat.com
         - tag: ubi9/ubi:9.4
+          registry: registry.access.redhat.com
+        - tag: ubi9/ubi:9.5
+          registry: registry.access.redhat.com
+        - tag: ubi9/ubi:9.6
+          registry: registry.access.redhat.com
+        - tag: ubi9/ubi:9.7
           registry: registry.access.redhat.com
 
     runs-on: ubuntu-latest

--- a/docs/changelog-fragments/801.contrib.rst
+++ b/docs/changelog-fragments/801.contrib.rst
@@ -1,0 +1,2 @@
+Added Fedora and ubi9 images to CI/CD pipeline that are relevant in 2026
+and removed EOL Fedora versions -- by :user:`Jakuje`.


### PR DESCRIPTION
##### SUMMARY
This increases test coverage with current libssh on platforms we need to support pylibssh.

##### ISSUE TYPE
 - CI/CD