### PR TITLE
📦 Bump build env pins to their last versions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -308,13 +308,17 @@ jobs:
         FILE_APPEND_MODE = 'a'
 
         whl_file_prj_base_name = '${{ env.PROJECT_NAME }}'.replace('-', '_')
-        sdist_file_prj_base_name = whl_file_prj_base_name.replace('.', '_')
+        sdist_file_prj_base_name = (
+            whl_file_prj_base_name.
+            replace('.', '_').
+            lower()
+        )
 
         with Path(environ['GITHUB_OUTPUT']).open(
                 mode=FILE_APPEND_MODE,
         ) as outputs_file:
             print(
-                "sdist=${{ env.PROJECT_NAME }}-${{
+                f"sdist={sdist_file_prj_base_name}-${{
                     steps.request-check.outputs.release-requested == 'true'
                     && github.event.inputs.release-version
                     || steps.scm-version.outputs.dist-version

--- a/.packit.yml
+++ b/.packit.yml
@@ -85,7 +85,7 @@ srpm_build_deps:  # The presense of `srpm_build_deps` enforces Copr env
 sync_changelog: false
 # synced_files: []
 
-upstream_package_name: ansible-pylibssh
+upstream_package_name: ansible_pylibssh
 upstream_project_url: https://github.com/ansible/pylibssh
 upstream_tag_template: v{version}
 

--- a/docs/changelog-fragments/808.contrib.rst
+++ b/docs/changelog-fragments/808.contrib.rst
@@ -1,0 +1,8 @@
+The CI/CD/packaging infrastructure has been updated to produce
+:external+packaging:term:`source distribution <Source Distribution (or "sdist")>`
+file names consistent with the requirement of uploading artifacts
+compliant with the core packaging metadata 2.2 or newer to PyPI and
+TestPyPI -- by :user:`webknjaz`.
+
+Along with that, the infrastructure has been adjusted to expect
+:pep:`625`-conforming names in its guard rails checks.

--- a/docs/changelog-fragments/808.packaging.rst
+++ b/docs/changelog-fragments/808.packaging.rst
@@ -1,0 +1,1 @@
+808.contrib.rst

--- a/packaging/rpm/ansible-pylibssh.spec
+++ b/packaging/rpm/ansible-pylibssh.spec
@@ -1,8 +1,11 @@
-%global pypi_name ansible-pylibssh
+%global canonical_project_name ansible-pylibssh
+%global pypi_name %canonical_project_name
+%global normalized_core_packaging_metadata_project_name %(echo '%canonical_project_name' | sed --regexp-extended 's:-:_:g;s:\\.:_:g')
+%global srcname %normalized_core_packaging_metadata_project_name
 
 # NOTE: The target version may be set dynamically via
 # NOTE: rpmbuild --define "upstream_version 0.2.1.dev125+g0b5bde0"
-%global upstream_version_fallback %(ls -t dist/%{pypi_name}-*.tar.gz 2>/dev/null | head -n 1 | sed 's#^dist\\/%{pypi_name}-\\(.*\\)\\.tar\\.gz$#\\1#')
+%global upstream_version_fallback %(ls -t dist/%{normalized_core_packaging_metadata_project_name}-*.tar.gz 2>/dev/null | head -n 1 | sed 's#^dist\\/%{normalized_core_packaging_metadata_project_name}-\\(.*\\)\\.tar\\.gz$#\\1#')
 # If "upstream_version" macro is unset, use the fallback defined above:
 %if "%{!?upstream_version:UNSET}" == "UNSET"
 %global upstream_version %{upstream_version_fallback}
@@ -68,7 +71,7 @@ Summary:        %{summary}
 $summary
 
 %prep
-%autosetup -p1 -n %{pypi_name}-%{version}
+%autosetup -p1 -n %{normalized_core_packaging_metadata_project_name}-%{version}
 
 %if 0%{?rhel} == 9
 # NOTE: Since RHEL 9 does not have setuptools-scm 7+ in the repos, we change the

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -12,7 +12,7 @@ packaging==26.0
     # via setuptools-scm
 pyparsing==3.3.2
     # via packaging
-setuptools-scm==9.2.2
+setuptools-scm==8.3.1
     # via -r -
 tomli==2.4.0
     # via setuptools-scm

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -4,25 +4,25 @@
 #
 #    pip-compile --allow-unsafe --output-file=requirements-build.txt --strip-extras -
 #
-cython==3.0.12
+cython==3.2.4
     # via -r -
-expandvars==0.9.0
+expandvars==1.1.2
     # via -r -
-packaging==24.0
+packaging==26.0
     # via setuptools-scm
-pyparsing==3.0.9
+pyparsing==3.3.2
     # via packaging
-setuptools-scm==8.1.0
+setuptools-scm==9.2.2
     # via -r -
-tomli==2.0.1
+tomli==2.4.0
     # via setuptools-scm
-typing-extensions==4.10.0
+typing-extensions==4.15.0
     # via setuptools-scm
-wheel==0.37.1
+wheel==0.46.3
     # via -r -
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==68.2.2
+setuptools==82.0.0
     # via
     #   -r -
     #   setuptools-scm


### PR DESCRIPTION
This will fix #799 by making use of a newer version of `setuptools` in CI that follows modern source distribution file base name normalization rules according to newer metadata version spec.

PyPI and TestPyPI now enforces that sdists must have the metadata version of 2.2 or higher. And metadata version 2.1 and higher have name format restrictions formalized that weren't there earlier [[1]].

[1]: https://packaging.python.org/en/latest/specifications/source-distribution-format/#source-distribution-file-format

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
SSIA.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Packaging Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
N/A