### PR TITLE
🧪 Mark armv7l images w/ `arm` OCI platform tag

### DIFF
--- a/.github/workflows/build-manylinux-container-images.yml
+++ b/.github/workflows/build-manylinux-container-images.yml
@@ -44,21 +44,26 @@ jobs:
         - _2_34
         include:
         - IMAGE:
-            ARCH: armv7l
+            ARCH_SUFFIX: armv7l
+            ARCH: arm
             HOST_OS: ubuntu-24.04-arm
           YEAR: _2_31  # There are no base images prior to 2.31 for this arch
 
     env:
       LIBSSH_VERSION: 0.12.0
       PYPA_MANYLINUX_TAG: >-
-        manylinux${{ matrix.YEAR }}_${{ matrix.IMAGE.ARCH }}
+        manylinux${{ matrix.YEAR }}_${{
+          matrix.IMAGE.ARCH_SUFFIX
+          || matrix.IMAGE.ARCH
+        }}
       FULL_IMAGE_NAME: >-
         ${{
           github.repository
         }}-manylinux${{
           matrix.YEAR
         }}_${{
-          matrix.IMAGE.ARCH
+          matrix.IMAGE.ARCH_SUFFIX
+          || matrix.IMAGE.ARCH
         }}
       QEMU_ARCH: ${{ matrix.IMAGE.QEMU_ARCH || matrix.IMAGE.ARCH }}
 
@@ -68,7 +73,10 @@ jobs:
 
     name: >-  # can't use `env` in this context:
       🐳
-      manylinux${{ matrix.YEAR }}_${{ matrix.IMAGE.ARCH }}
+      manylinux${{ matrix.YEAR }}_${{
+        matrix.IMAGE.ARCH_SUFFIX
+        || matrix.IMAGE.ARCH
+      }}
     steps:
     - name: Fetch the repo src
       uses: actions/checkout@v4.1.6
@@ -76,7 +84,7 @@ jobs:
         Set up QEMU ${{ env.QEMU_ARCH }} arch emulation
         with Podman
       if: >-
-        !contains(fromJSON('["aarch64", "amd64", "armv7l"]'), env.QEMU_ARCH)
+        !contains(fromJSON('["aarch64", "amd64", "arm"]'), env.QEMU_ARCH)
       run: >
         sudo podman run
         --rm --privileged

--- a/docs/changelog-fragments/810.contrib.rst
+++ b/docs/changelog-fragments/810.contrib.rst
@@ -1,0 +1,3 @@
+The pre-cached ``armv7l`` images we build for the packaging
+infrastructure are now correctly tagged with the ``linux/arm/v7``
+OCI platform tag -- by :user:`webknjaz`.

--- a/docs/changelog-fragments/810.packaging.rst
+++ b/docs/changelog-fragments/810.packaging.rst
@@ -1,0 +1,1 @@
+810.contrib.rst


### PR DESCRIPTION
This fix is a continuation of #692 that is supposed to unblock #648. The outcome will be that the `armv7l` images we build are correctly tagged with the `linux/arm/v7` OCI platform tag.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
SSIA.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Packaging Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
#648 revealed that the `armv7l` images we build are tagged as `linux/armv7l/v7` but should be `linux/arm/v7`:
```console
  Status: Downloaded newer image for ghcr.io/ansible/pylibssh-manylinux_2_31_armv7l:libssh-v0.12.0
  WARNING: image with reference ghcr.io/ansible/pylibssh-manylinux_2_31_armv7l:libssh-v0.12.0 was found but its platform (linux/armv7l/v7) does not match the specified platform (linux/arm/v7)
  docker: Error response from daemon: image with reference ghcr.io/ansible/pylibssh-manylinux_2_31_armv7l:libssh-v0.12.0 was found but its platform (linux/armv7l/v7) does not match the specified platform (linux/arm/v7)
```

The build logs used to have this warning that got overlooked:
```console
WARNING: image platform (linux/arm/v7) does not match the expected platform (linux/armv7l)
```