### PR TITLE
Document Python 3.13/3.14 source build requirements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,16 @@ pylibssh requires libssh to be installed in particular:
   To install libssh refer to its `Downloads page
   <https://www.libssh.org/get-it/>`__.
 
+.. note::
+
+   If a pre-built wheel is not available for your Python
+   version (for example, on newer Python releases),
+   ``pip install ansible-pylibssh`` will compile from source
+   automatically, but requires ``libssh`` development headers
+   and a C compiler to be installed first. See the
+   `documentation <https://ansible-pylibssh.rtfd.io/>`__
+   for platform-specific commands.
+
 
 Building the module
 -------------------

--- a/docs/changelog-fragments/813.doc.rst
+++ b/docs/changelog-fragments/813.doc.rst
@@ -1,0 +1,5 @@
+Added installation guidance for Python 3.13 and 3.14 users,
+who must build from source until pre-built wheels are
+published. Documented platform-specific commands for
+installing ``libssh`` development headers on macOS, Debian /
+Ubuntu, and RHEL / Fedora, by :user:`cidrblock`.

--- a/docs/changelog-fragments/813.doc.rst
+++ b/docs/changelog-fragments/813.doc.rst
@@ -2,4 +2,4 @@ Added installation guidance for Python 3.13 and 3.14 users,
 who must build from source until pre-built wheels are
 published. Documented platform-specific commands for
 installing ``libssh`` development headers on macOS, Debian /
-Ubuntu, and RHEL / Fedora, by :user:`cidrblock`.
+Ubuntu, and RHEL / Fedora -- by :user:`cidrblock`.

--- a/docs/installation_guide.rst
+++ b/docs/installation_guide.rst
@@ -28,6 +28,15 @@ dependencies on your system.
 It should be enough for you to just have Python 3.9+ and
 a recent :std:doc:`pip <pip:index>` installed.
 
+.. note::
+
+    Pre-built wheels are not yet available for Python 3.13 and
+    3.14. When no wheel is available,
+    ``pip install`` will automatically
+    attempt to compile the package from source. For this to
+    succeed, you must first install the system dependencies
+    listed in :ref:`install-from-source` below.
+
 .. attention::
 
     Please make sure you have the latest version of
@@ -60,18 +69,48 @@ To install |project|, just run:
     understand fully the implications of modifying global
     files on the system.
 
+.. _install-from-source:
+
 Installing |project| from source distribution (PyPI)
 ====================================================
 
 Installing |project| from source is a bit more complicated.
 First, pylibssh requires libssh to be compiled against, in
-particular, version 0.9.0 or newer. Please refer to `libssh
-Downloads page <https://www.libssh.org/get-it/>`__ for more
-information about installing it. Make sure that you have the
-development headers too.
+particular, version 0.9.0 or newer. Make sure that you have
+the development headers too.
 
-Another essential build dependency is GCC. You may already
-have it installed but if not, consult with your OS docs.
+You will also need a C compiler such as GCC. Below are the
+install commands for common platforms:
+
+**macOS**:
+
+.. code-block:: shell-session
+
+    $ xcode-select --install  # one-time setup for the C compiler
+    $ brew install libssh
+
+**Debian / Ubuntu**:
+
+.. code-block:: shell-session
+
+    $ sudo apt-get install libssh-dev build-essential python3-dev
+
+**RHEL / Fedora / CentOS Stream**:
+
+.. code-block:: shell-session
+
+    $ sudo dnf install libssh-devel gcc python3-devel
+
+For other platforms, refer to the `libssh Downloads page
+<https://www.libssh.org/get-it/>`__.
+
+.. note::
+
+    Python 3.13 requires ``Cython >= 3.0.11`` and Python 3.14
+    requires ``Cython >= 3.1.0`` to compile the C-extensions.
+    When building from source via :std:doc:`pip <pip:index>`,
+    the correct version is pulled automatically by the
+    :pep:`517` build backend.
 
 Once you have the build prerequisites, the following command
 should download the tarball, build it and then install into

--- a/docs/installation_guide.rst
+++ b/docs/installation_guide.rst
@@ -106,8 +106,8 @@ For other platforms, refer to the `libssh Downloads page
 
 .. note::
 
-    Python 3.13 requires ``Cython >= 3.0.11`` and Python 3.14
-    requires ``Cython >= 3.1.0`` to compile the C-extensions.
+    Python 3.13 and later require ``Cython >= 3.0.11`` to compile
+    the C-extensions.
     When building from source via :std:doc:`pip <pip:index>`,
     the correct version is pulled automatically by the
     :pep:`517` build backend.


### PR DESCRIPTION
##### SUMMARY

Pre-built wheels are not yet available for Python 3.13 and 3.14. When no
wheel is available, `pip install` will automatically attempt to compile from
source, but this requires system dependencies that were not documented.

- Add a note about wheel availability to the installation guide and README,
  clarifying that `pip install` still works but needs system deps first
- Replace generic "consult your OS docs" with concrete install commands for
  macOS (Homebrew), Debian/Ubuntu (apt), and RHEL/Fedora/CentOS (dnf)
- Document the Cython version requirements for Python 3.13 (`>= 3.0.11`)
  and 3.14 (`>= 3.1.0`)

##### ISSUE TYPE
- Docs Pull Request

##### ADDITIONAL INFORMATION

Files changed:
- `docs/installation_guide.rst` — wheel availability note, platform-specific
  install commands, Cython version requirements
- `README.rst` — brief note pointing users to the installation guide
- `docs/changelog-fragments/0.doc.rst` — changelog fragment