### PR TITLE
Expand contributor guide with PR expectations and process

### DIFF
--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -13,7 +13,24 @@ Contributing to ansible-pylibssh
    improving our CI, testing and packaging, we will gladly review it.
 
 
-In order to contribute, you'll need to:
+Before you start
+================
+
+  1. **Check for existing work.** Search open `pull requests`_ and
+     `issues`_ to see if someone is already working on the same area.
+     This avoids duplicate effort and conflicting changes.
+
+  2. **Review the** ``devel`` **branch.** Look at recent commits and
+     in-flight PRs to understand what is currently being worked on.
+
+  3. **Discuss scope first.** If your change touches multiple areas
+     (e.g. CI, packaging, and documentation), open an issue to
+     discuss the approach before writing code. Smaller, focused
+     changes are easier to review and merge.
+
+
+How to contribute
+=================
 
   1. Fork the repository.
 
@@ -21,23 +38,113 @@ In order to contribute, you'll need to:
      :ref:`include news files for the changelog <Adding change
      notes with your PRs>`.
 
-  3. Send it to us as a PR.
+  3. Send it to us as a PR. Fill out the `pull request template`_
+     completely — including **SUMMARY**, **ISSUE TYPE**, and
+     **ADDITIONAL INFORMATION**.
 
   4. Iterate on your PR, incorporating the requested improvements
      and participating in the discussions.
 
-Prerequisites:
+
+Pull request expectations
+=========================
+
+- **Prefer focused, atomic PRs** that address a single concern.
+  Mixing unrelated changes (e.g. dependency bumps with test
+  infrastructure changes) makes review harder and slows down
+  the merge process.
+
+- **Fill out the PR template.** PRs that do not use the template
+  may be asked to resubmit. The template helps reviewers
+  understand the rationale and scope of the change.
+
+- **Include changelog fragments** for user-visible changes.
+  See :ref:`Adding change notes with your PRs` for the format,
+  categories, and available reStructuredText roles.
+
+- **Understand the project context.** ansible-pylibssh is a
+  Cython-based C-extension project with a custom :pep:`517`
+  build backend. If your change touches the build system,
+  CI workflows, or packaging, take time to understand how the
+  existing pieces fit together before proposing changes.
+
+
+CI and merge process
+====================
+
+- Before submitting, make sure the linters pass locally:
+
+  .. code-block:: shell-session
+
+     $ tox -e lint
+
+- All GitHub Actions lint, test, and build checks should pass
+  on your PR.
+
+- Packit (RPM) checks may have pre-existing failures on
+  ``devel``. If your PR shows Packit failures that also exist
+  on the base branch, note this in a PR comment.
+
+- The maintainer may fast-track infrastructure and packaging
+  changes without external review. External contributions go
+  through a full review cycle.
+
+
+AI-assisted contributions
+=========================
+
+AI tools may be used to assist with contributions. However:
+
+- **The PR author is solely accountable** for every line
+  submitted. "The AI generated it" is not a justification
+  for incorrect or inappropriate changes. Be ready to discuss
+  your changes and justify every line.
+
+- **Authors must demonstrate understanding** of the changes
+  and familiarity with the project context. PRs that appear
+  to lack project-specific understanding may be asked for
+  clarification or closed.
+
+- **Communicate as yourself.** When interacting in issues,
+  pull requests, and discussions, do not use AI tools to speak
+  for you (except for translation or grammar edits).
+  Human-to-human communication is foundational to open source
+  communities.
+
+- **No autonomous submissions.** The use of agents that write
+  code and submit pull requests without human review is not
+  permitted.
+
+- **Respect the project's conventions.** AI tools may not be
+  aware of this project's build system, changelog format, or
+  PR template. Review AI-generated output against the
+  guidelines in this document before submitting.
+
+- **Try to be brief.** Recognize when less is more. Aim for
+  changes that reduce complexity rather than add to it.
+
+.. note::
+
+   Issues labeled ``good first issue`` are intended as learning
+   opportunities for new contributors. Please be considerate of
+   those who may benefit from these opportunities, and refrain
+   from asking an AI tool to produce a complete solution.
+
+.. caution::
+
+   In extreme cases, low-quality PRs may be closed as spam.
+
+
+Prerequisites
+=============
 
   1. Have libssh_.
 
   2. Use tox_ to build the C-extension, docs and run the tests.
 
-  3. Before sending a PR, make sure that the linters pass:
-
-     .. code-block:: shell-session
-
-        $ tox -e lint
-
 
 .. _libssh: https://www.libssh.org
 .. _tox: https://tox.readthedocs.io
+.. _pull requests: https://github.com/ansible/pylibssh/pulls
+.. _issues: https://github.com/ansible/pylibssh/issues
+.. _pull request template: https://github.com/ansible/pylibssh/blob/devel/.github/PULL_REQUEST_TEMPLATE.md

--- a/docs/changelog-fragments/814.contrib.rst
+++ b/docs/changelog-fragments/814.contrib.rst
@@ -1,0 +1,4 @@
+Expanded the contributor guide with guidance on checking for
+existing work, PR scope and template expectations, CI and merge
+process, AI-assisted contributions, and available RST roles for
+changelog fragments, by :user:`cidrblock`.

--- a/docs/changelog-fragments/814.contrib.rst
+++ b/docs/changelog-fragments/814.contrib.rst
@@ -1,4 +1,4 @@
 Expanded the contributor guide with guidance on checking for
 existing work, PR scope and template expectations, CI and merge
 process, AI-assisted contributions, and available RST roles for
-changelog fragments, by :user:`cidrblock`.
+changelog fragments -- by :user:`cidrblock`.

--- a/docs/changelog-fragments/README.rst
+++ b/docs/changelog-fragments/README.rst
@@ -33,7 +33,22 @@ combined with others, it will be a part of the "news digest"
 telling the readers **what changed** in a specific version of
 the library *since the previous version*. You should also use
 *reStructuredText* syntax for highlighting code (inline or block),
-linking parts of the docs or external sites.
+linking parts of the docs or external sites. The following
+roles are available when writing fragments:
+
+- Custom roles configured via ``extlinks`` in the project's
+  Sphinx configuration (``docs/conf.py``):
+
+  - ``:user:`github-username``` — link to a GitHub Sponsors profile
+  - ``:issue:`123``` — link to a GitHub issue
+  - ``:pr:`123``` — link to a pull request
+  - ``:gh:`org/repo``` — link to a GitHub repository
+  - ``:commit:`sha``` — link to a specific commit
+
+- Built-in Sphinx role:
+
+  - ``:pep:`517``` — link to a Python Enhancement Proposal
+
 However, you do not need to reference the issue or PR numbers here
 as *towncrier* will automatically add a reference to all of the
 affected issues when rendering the news file.


### PR DESCRIPTION
##### SUMMARY

The contributor guide covered only the basics (fork, branch, PR, lint).
This expands it with practical guidance that helps external contributors
submit PRs that align with the project's expectations.

New sections:
- **Before you start** — check for existing work, review `devel`, discuss
  scope for multi-area changes
- **Pull request expectations** — atomic PRs, use the template, include
  changelog fragments, understand project context
- **CI and merge process** — which checks must pass, how to handle
  pre-existing Packit failures, maintainer fast-track for infra changes
- **AI-assisted contributions** — AI tools are welcome, but the author is
  accountable for every line and must demonstrate understanding of the
  changes and project context

Also adds a reference listing the available RST roles (`:user:`, `:issue:`,
`:pr:`, `:gh:`, `:commit:`, `:pep:`) to the changelog fragments README.

##### ISSUE TYPE
- Docs Pull Request

##### ADDITIONAL INFORMATION

Files changed:
- `.github/CONTRIBUTING.rst` — expanded with new sections
- `docs/changelog-fragments/README.rst` — added RST roles reference
- `docs/changelog-fragments/814.contrib.rst` — changelog fragment