### PR TITLE
🧪 Make Python 3.13 and 3.14 supported officially

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -27,6 +27,11 @@ show_missing = true
 
 [run]
 branch = true
+# NOTE: `ctrace` tracing method is needed because the `sysmon` tracer
+# NOTE: which is default on Python 3.14, causes unprecedented slow-down
+# NOTE: of the test runs. Also, Cython plugins do not support it.
+# Ref: https://github.com/coveragepy/coveragepy/issues/2099
+core = ctrace
 cover_pylib = false
 # NOTE: `disable_warnings` is needed when `pytest-cov` runs in tandem
 # NOTE: with `pytest-xdist`. These warnings are false negative in this

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -782,7 +782,7 @@ jobs:
         store-sdist-to-artifact:
         - false
         include:
-        - python-version: 3.12
+        - python-version: 3.14
           runner-vm-os: ubuntu-22.04
           store-sdist-to-artifact: true
 
@@ -1163,6 +1163,8 @@ jobs:
     strategy:
       matrix:
         python-version:
+        - "3.14"
+        - "3.13"
         - "3.12"
         - "3.11"
         - "3.10"
@@ -1201,6 +1203,8 @@ jobs:
     strategy:
       matrix:
         python-version:
+        - "3.14"
+        - "3.13"
         - "3.12"
         - "3.11"
         - "3.10"

--- a/docs/changelog-fragments/809.contrib.3.rst
+++ b/docs/changelog-fragments/809.contrib.3.rst
@@ -1,0 +1,1 @@
+825.contrib.1.rst

--- a/docs/changelog-fragments/809.contrib.4.rst
+++ b/docs/changelog-fragments/809.contrib.4.rst
@@ -1,0 +1,1 @@
+825.contrib.2.rst

--- a/docs/changelog-fragments/809.packaging.5.rst
+++ b/docs/changelog-fragments/809.packaging.5.rst
@@ -1,0 +1,1 @@
+825.packaging.rst

--- a/docs/changelog-fragments/825.contrib.1.rst
+++ b/docs/changelog-fragments/825.contrib.1.rst
@@ -1,0 +1,2 @@
+The CI now tests wheels built for Python 3.13 and 3.14
+-- by :user:`cidrblock` and :user:`webknjaz`.

--- a/docs/changelog-fragments/825.contrib.2.rst
+++ b/docs/changelog-fragments/825.contrib.2.rst
@@ -1,0 +1,3 @@
+The coverage measurement infrastructure now uses the ``ctrace``
+:external+coveragepy:std:ref:`measurement core <config_run_core>`
+across all the Python versions consistently -- by :user:`webknjaz`.

--- a/docs/changelog-fragments/825.packaging.rst
+++ b/docs/changelog-fragments/825.packaging.rst
@@ -1,0 +1,3 @@
+The core packaging metadata now reflects that we test the project under
+Python 3.13 and 3.14 (with GIL enabled)
+-- by :user:`cidrblock` and :user:`webknjaz`.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -138,6 +138,7 @@ master_doc = 'index'
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
+    'coveragepy': ('https://coverage.readthedocs.io/en/latest', None),
     'cython': ('https://cython.readthedocs.io/en/latest', None),
     'packaging': ('https://packaging.python.org', None),
     'pip': ('https://pip.pypa.io/en/latest', None),

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,8 @@ classifiers =
   Programming Language :: Python :: 3.10
   Programming Language :: Python :: 3.11
   Programming Language :: Python :: 3.12
+  Programming Language :: Python :: 3.13
+  Programming Language :: Python :: 3.14
   Programming Language :: Cython
 
   Topic :: Software Development :: Libraries :: Python Modules


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This change fully integrates the infrastructure for testing the wheels built for Python 3.13 and 3.14. It also reflects this in the core packaging metadata as Trove classifiers.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request
- Packaging Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Some of the initial effort is coming from #809 and a few other experimental PRs that didn't end up complete. The coverage configuration needed to be included in the scope of this PR as there was a warning-turned-error that was happening in newly-added Python 3.14 jobs.