### PR TITLE
Add Centos 10 Stream build

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -954,6 +954,8 @@ jobs:
           registry: registry.access.redhat.com
         - tag: ubi9/ubi:9.7
           registry: registry.access.redhat.com
+        - tag: centos/centos:stream10
+          registry: quay.io
 
     runs-on: ubuntu-latest
 
@@ -988,6 +990,13 @@ jobs:
       run: |
         dist_tag=$(rpm --eval '%{?dist}')
         echo "dist-tag=${dist_tag}" >> "${GITHUB_OUTPUT}"
+
+    - name: Install epel and enable CRB repository for centos
+      if: contains(matrix.target-container.tag, 'centos')
+      run: >-
+        dnf config-manager --set-enabled crb &&
+        dnf install -y
+        https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
 
     - name: Install build tooling
       run: >-

--- a/docs/changelog-fragments/830.contrib.rst
+++ b/docs/changelog-fragments/830.contrib.rst
@@ -1,0 +1,1 @@
+Added Centos 10 Stream image to the CI/CD pipeline -- by :user:`Jakuje`.


### PR DESCRIPTION
##### SUMMARY
This is alternative to #805, which attempted to add ubi10, but failed on missing python-cython from the ubi images.

They should be though in the centos 10 stream.

##### ISSUE TYPE
- Feature Pull Request