### PR TITLE
Update vendored libssh in platform-specific wheels to v0.12.2

### DIFF
--- a/docs/changelog-fragments/847.contrib.rst
+++ b/docs/changelog-fragments/847.contrib.rst
@@ -1,0 +1,2 @@
+Updated the bundled version of libssh to 0.12.2 in platform-specific
+wheels published on PyPI -- by :user:`Jakuje`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,11 +222,11 @@ PRE_COMMIT_COLOR = "always"
 PY_COLORS = "1"
 
 [tool.cibuildwheel.linux]
-manylinux-aarch64-image = "ghcr.io/ansible/pylibssh-manylinux_2_28_aarch64:libssh-v0.12.0"
-manylinux-armv7l-image = "ghcr.io/ansible/pylibssh-manylinux_2_31_armv7l:libssh-v0.12.0"
-manylinux-ppc64le-image = "ghcr.io/ansible/pylibssh-manylinux_2_28_ppc64le:libssh-v0.12.0"
-manylinux-s390x-image = "ghcr.io/ansible/pylibssh-manylinux_2_28_s390x:libssh-v0.12.0"
-manylinux-x86_64-image = "ghcr.io/ansible/pylibssh-manylinux_2_28_x86_64:libssh-v0.12.0"
+manylinux-aarch64-image = "ghcr.io/ansible/pylibssh-manylinux_2_28_aarch64:libssh-v0.12.2"
+manylinux-armv7l-image = "ghcr.io/ansible/pylibssh-manylinux_2_31_armv7l:libssh-v0.12.2"
+manylinux-ppc64le-image = "ghcr.io/ansible/pylibssh-manylinux_2_28_ppc64le:libssh-v0.12.2"
+manylinux-s390x-image = "ghcr.io/ansible/pylibssh-manylinux_2_28_s390x:libssh-v0.12.2"
+manylinux-x86_64-image = "ghcr.io/ansible/pylibssh-manylinux_2_28_x86_64:libssh-v0.12.2"
 skip = [
   "*-musllinux_*",  # FIXME: musllinux needs us to provide with containers pre-built libssh
 


### PR DESCRIPTION
##### SUMMARY

Follow-up from #846

##### ISSUE TYPE
- Feature Pull Request
