### PR TITLE
packit: Correctly find generated tarball

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -24,8 +24,9 @@ actions:
   get-current-version:
   - >-
     bash -c "
-      python3 -m setuptools_scm  | sed 's/.*Guessed Version\s\+//g'
-    "
+      python3 -Im setuptools_scm \
+        | sed 's/.*Guessed Version\s\+//g' \
+        | sed -E 's/\+g([0-9a-f]{7})[0-9a-f]*/+g\1/'"
 
 # allowed_gpg_keys:
 # - 5DE3E0509C47EA3CF04A42D34AEE18F83AFDEB23  # GH web UI commit signing key

--- a/docs/changelog-fragments/848.contrib.rst
+++ b/docs/changelog-fragments/848.contrib.rst
@@ -1,0 +1,2 @@
+Fixed Packit CI caused by ``setuptools_scm`` version mismatch
+in build environment -- by :user:`Jakuje`.


### PR DESCRIPTION
##### SUMMARY
The checkout in CI should be clean so this should be the only file in the dist/ directory.

##### ISSUE TYPE
- Bugfix Pull Request

##### ADDITIONAL INFORMATION

the logs from recent runs
```
Before this change, the packit was failing to find the tarball, due to different setuptools_scm versions at different stages (see the built generated 7 characters hash, while the packit expected 9 characters git hash:

    Successfully built ansible_pylibssh-1.4.1.dev8+g2a52685.tar.gz
    Command: sh -c echo dist/"${PACKIT_PROJECT_NAME_VERSION}".tar.gz
    dist/ansible_pylibssh-1.4.1.dev8+g2a5268548.tar.gz

```
