### PR TITLE
ci: Drop Fedora 42

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -935,7 +935,6 @@ jobs:
     strategy:
       matrix:
         target-container:
-        - tag: fedora:42
         - tag: fedora:43
         - tag: fedora:44
         - tag: ubi9/ubi:9.0.0

--- a/docs/changelog-fragments/852.contrib.rst
+++ b/docs/changelog-fragments/852.contrib.rst
@@ -1,0 +1,1 @@
+Dropped the EOL Fedora 42 from CI targets -- by :user:`Jakuje`.


### PR DESCRIPTION
##### SUMMARY
The Fedora 42 is EOL

##### ISSUE TYPE
- CI Pull Request