### PR TITLE
🤖 Bootstrap agent context infrastructure

### DIFF
--- a/.agents-ctx/.gitignore
+++ b/.agents-ctx/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!*.md

--- a/.agents-ctx/CONTRIB_WORKFLOW_INFRA_TOOLING.md
+++ b/.agents-ctx/CONTRIB_WORKFLOW_INFRA_TOOLING.md
@@ -1,0 +1,80 @@
+# Workflow & Tooling Infrastructure
+
+The project uses `tox` as the single entry point for all local
+automation -- the same one CI and core devs use. Agents must
+never bypass it by invoking the wrapped tools (`pytest`,
+`pre-commit`, `coverage`, `towncrier`, etc.) directly; doing so
+skips project-specific configuration and is liable to run with
+unsupported, undefined, or outright dangerous defaults.
+
+## `tox list` is the source of truth
+
+The contributing docs mention some environments, but that's not
+exhaustive or authoritative -- `tox list` is. Run it to see
+every available environment, each with its own description.
+Don't assume an environment exists, or what it does, without
+checking there first.
+
+## Running tests
+
+`tox run -e py` runs the test suite under whichever Python
+runtime is currently active. Other environments cover other
+purposes (lint, docs build, changelog draft/check, packaging,
+etc.) -- check `tox list` rather than assuming `py` is the only
+one relevant to a given task.
+
+## Default to low verbosity
+
+Prefer `tox run -e py -qq` by default. Only reach for more
+verbose tox-level output (drop the `-q`, or add `-v`/`-vv`) once
+there's an actual reason to inspect tox's own internals -- don't
+lead with a wall of logs.
+
+## `pyNNN`-style environment names are native tox behavior
+
+`tox run -e py312` isn't something this project specifically
+configured -- it's tox's own built-in convention: an env name
+matching `pyNN`/`pyNNN` makes tox look up a `python3.N`
+interpreter and create/use `.tox/py312` for it, if available.
+This, and other generic tox mechanics not specific to this
+project, are covered by tox's own documentation -- read that
+rather than expecting everything generic about tox to be
+re-explained here.
+
+## Passing arguments through to the wrapped tool
+
+Arguments after a bare `--` are forwarded to whatever tool the
+environment wraps. For example, `tox run -e py -- -n0` passes
+`-n0` to `pytest`, disabling `pytest-xdist` parallelism for that
+run -- safe here since this project's `py`/`just-pytest` envs
+both use a bare `{posargs:}` with an empty default in `tox.ini`,
+so there's nothing to lose.
+
+That's not true everywhere, though: when a `commands =` line uses
+`{posargs:<default value>}` with a *non-empty* default, anything
+passed after `--` **replaces that default wholesale** -- it does
+not get appended to it. Two real examples from this project's own
+`tox.ini`:
+
+- `build-docs`'s Sphinx invocation defaults to a full flag set
+  (`-j auto -b html ... -a -n -W --keep-going -d ... . <output>`)
+  via `{posargs:...}` -- passing any custom posargs there replaces
+  the whole thing, not just adds to it.
+- `make-changelog`'s default posargs are `'[UNRELEASED DRAFT]'
+  --draft` (draft-preview mode); its own `description` field
+  documents overriding this deliberately -- passing a real version
+  after `--` (e.g. `tox run -e make-changelog -- 1.3.2`) switches
+  it into actually cutting that release, dropping `--draft`
+  entirely.
+
+Always check what a given env's default posargs actually are
+(`tox config -e <env>`, or read `tox.ini`) before assuming `--`
+just "adds more flags."
+
+## Read the tool's own output
+
+`build-docs` prints follow-up instructions after running -- where
+the built HTML docs landed, and how to serve them locally. `lint`
+prints a reminder of how to install its pre-commit hooks into
+Git. Read what the invocation actually printed instead of
+guessing a path or a next step.

--- a/.agents-ctx/HOUSE_RULES.md
+++ b/.agents-ctx/HOUSE_RULES.md
@@ -4,6 +4,33 @@
 >
 > This is how we do things here, get used to it.
 
+## Operating mode
+
+> [!important]
+>
+> Bidirectional quizzing is mandatory. Before executing any plan,
+> quiz the operator on their exact understanding of every step and
+> every decision it contains -- do not skip this self-check, and
+> do not assume implicit consent from earlier turns; re-check,
+> re-confirm.
+
+Concretely:
+
+- Read the relevant files in full before proposing edits -- never
+  guess what they currently contain.
+- Show diffs for non-trivial changes and pause for explicit
+  approval.
+- Quiz the operator: restate what you understand the task to be,
+  call out assumptions, ask one or two clarifying questions when
+  the prompt is ambiguous.
+- Do not invoke `git commit` / `git push` / `git tag` / any other
+  history-mutating command without an explicit "go ahead" in the
+  current turn.
+- Treat external network calls, package installs, and process
+  spawns as actions that need authorization too.
+- When in doubt, ask. The operator prefers a clarifying question
+  over an unwound mistake.
+
 ## Naming the ducks
 
 See [NAMING_THE_DUCKS.md](NAMING_THE_DUCKS.md) for the project's

--- a/.agents-ctx/HOUSE_RULES.md
+++ b/.agents-ctx/HOUSE_RULES.md
@@ -1,0 +1,11 @@
+# House Rules
+
+> [!tip]
+>
+> This is how we do things here, get used to it.
+
+## Coding style and architecture
+
+See [HOUSE_STYLE.md](HOUSE_STYLE.md) for coding style and
+architectural/structural conventions, including the rule against
+introducing new `@`-syntax in memory files.

--- a/.agents-ctx/HOUSE_RULES.md
+++ b/.agents-ctx/HOUSE_RULES.md
@@ -20,3 +20,9 @@ introducing new `@`-syntax in memory files.
 
 See [PR_HYGIENE.md](PR_HYGIENE.md) for scope, changelog-fragment,
 and naming conventions maintainers consistently enforce in review.
+
+## Tooling
+
+See [CONTRIB_WORKFLOW_INFRA_TOOLING.md](CONTRIB_WORKFLOW_INFRA_TOOLING.md)
+for how to run tests, linters, and other project automation --
+always through `tox`, never by invoking the wrapped tools directly.

--- a/.agents-ctx/HOUSE_RULES.md
+++ b/.agents-ctx/HOUSE_RULES.md
@@ -16,6 +16,11 @@ See [HOUSE_STYLE.md](HOUSE_STYLE.md) for coding style and
 architectural/structural conventions, including the rule against
 introducing new `@`-syntax in memory files.
 
+## Testing
+
+See [TESTING.md](TESTING.md) for how tests are written and
+structured in this project.
+
 ## PR and commit hygiene
 
 See [PR_HYGIENE.md](PR_HYGIENE.md) for scope, changelog-fragment,

--- a/.agents-ctx/HOUSE_RULES.md
+++ b/.agents-ctx/HOUSE_RULES.md
@@ -15,3 +15,8 @@ to use where.
 See [HOUSE_STYLE.md](HOUSE_STYLE.md) for coding style and
 architectural/structural conventions, including the rule against
 introducing new `@`-syntax in memory files.
+
+## PR and commit hygiene
+
+See [PR_HYGIENE.md](PR_HYGIENE.md) for scope, changelog-fragment,
+and naming conventions maintainers consistently enforce in review.

--- a/.agents-ctx/HOUSE_RULES.md
+++ b/.agents-ctx/HOUSE_RULES.md
@@ -4,6 +4,12 @@
 >
 > This is how we do things here, get used to it.
 
+## Naming the ducks
+
+See [NAMING_THE_DUCKS.md](NAMING_THE_DUCKS.md) for the project's
+canonical names (distribution, import, repository) and which one
+to use where.
+
 ## Coding style and architecture
 
 See [HOUSE_STYLE.md](HOUSE_STYLE.md) for coding style and

--- a/.agents-ctx/HOUSE_STYLE.md
+++ b/.agents-ctx/HOUSE_STYLE.md
@@ -1,0 +1,15 @@
+# House Style
+
+## No new `@`-syntax in memory files
+
+Do not introduce additional Claude `@`-mention/import syntax inside
+any file under `.agents-ctx/`. The existing chain (`CLAUDE.md` ->
+`AGENTS.md` -> `.agents-ctx/HOUSE_RULES.md`) is the only sanctioned
+use of `@`-imports.
+
+`@`-mentions load eagerly, at the start of every session, whether
+or not the content ends up being relevant. Everything reachable
+from `HOUSE_RULES.md` onward links to further material with plain
+Markdown links instead, so an agent can pull it into context on
+demand -- when a task actually needs it -- rather than having the
+whole tree pollute the context window up front.

--- a/.agents-ctx/NAMING_THE_DUCKS.md
+++ b/.agents-ctx/NAMING_THE_DUCKS.md
@@ -1,0 +1,34 @@
+# Naming the Ducks
+
+Canonical names for this project, and how to refer to it in
+prose. Other files in `.agents-ctx/` (and any generated content)
+should say "the project" rather than hardcoding one of these --
+reach for a specific name only when the distinction actually
+matters (e.g. citing a package, an import, or a repository URL).
+
+## Distribution / PyPI name: `ansible-pylibssh`
+
+The installable, published name -- currently recorded in
+`setup.cfg`'s `[metadata]` `name`, expected to move to
+`pyproject.toml`'s `[project].name` per PEP 621 once that
+migration is possible. This is also the preferred way to refer
+to the project by name in prose.
+
+## Python import name: `pylibsshext`
+
+`import pylibsshext` is what code actually imports.
+Long-standing and unlikely to change without a dedicated,
+long-term migration effort -- don't "fix" it opportunistically.
+
+## GitHub repository slug: `ansible/pylibssh`
+
+Close to, but not the same as, the distribution name above. Use
+it verbatim when it's actually the repository being referenced
+(URLs, `gh` invocations, PR/issue citations) -- not as a
+stand-in for the project's name in prose.
+
+## Don't say bare `pylibssh`
+
+`pylibssh` on its own is just the default local directory name
+from a `git clone`d checkout -- nothing more. It's a common but
+incorrect shorthand; prefer `ansible-pylibssh` instead.

--- a/.agents-ctx/PR_HYGIENE.md
+++ b/.agents-ctx/PR_HYGIENE.md
@@ -1,0 +1,72 @@
+# PR & Commit Hygiene
+
+Grounded in the project's own review history, plus explicit
+maintainer conventions carried over from other projects — not
+guesses.
+
+## Point contributors to the official guidelines
+
+Route contributors to
+<https://ansible-pylibssh.rtfd.io/en/latest/contributing/guidelines>
+for the canonical contribution process, rather than improvising or
+restating it secondhand.
+
+## Keep PRs and commits atomic and scoped
+
+One conceptual change per PR, one conceptual change per commit.
+"I'm definitely not going to accept a bunch of unrelated changes
+smashed together" (PR #809); a PR mixing formatting, docstring
+rewording, and a behavior change got split into three (PR #862)
+before being accepted. Rebase onto the target branch for real
+instead of adding merge commits ("foxtrot merges") to a feature
+branch.
+
+## Don't dump AI-generated bloat
+
+"LLMs are good at generating way too much stuff and it even works
+under some circumstances but we're still responsible for keeping
+the patches maintainable, having Git tree tell a story and contain
+sufficient context. Be accountable." (PR #790) -- trim anything not
+directly related to the stated change before proposing it.
+
+## Every change needs a changelog fragment
+
+One fragment per PR, filed under `docs/changelog-fragments/` as
+`<issue/PR#>.<type>.rst`.
+
+A changelog fragment is not a restated commit message -- it covers
+everything since the previous release, for end-users, not
+developers. See `docs/changelog-fragments/README.rst` for the full
+rationale, including why changelog entries are a permanent
+historical record (never retroactively removed, even if the
+underlying code is later reverted) unlike commit history, which
+can be reworded, rebased, or squashed.
+
+Recurring, specific review feedback:
+
+- One change per fragment, not several changes "smashed" into one
+  (#756, #862).
+- Wording is past-tense and end-user-facing, not
+  imperative/developer-facing.
+- Reference related issues/PRs using `sphinx-issues` roles
+  (`:pr:`, `:user:`, `:file:`) instead of raw links or backticks
+  (#620, #786, #790, #809).
+
+## Names and docstrings carry the meaning, not comments
+
+"Comments repeating what the code does are pointless. Proper
+identifier names should be used instead" (PR #621). Docstrings
+describe what a function does; motivation/rationale, if needed,
+belongs in a comment or the PR description, not the docstring
+(PR #658).
+
+## Common micro-conventions flagged in review
+
+- f-strings over `.format()`/`%` formatting.
+- `contextlib.suppress()` over bare `try`/`except: pass`.
+- No monkey-patching stdlib.
+- Type annotations required on new/touched code; alias
+  `import typing as _t` for standard-library typing constructs
+  (e.g. `_t.Optional[...]`).
+- Public vs. private intent must be explicit -- prefix with `_` if
+  not part of the public API.

--- a/.agents-ctx/README.md
+++ b/.agents-ctx/README.md
@@ -1,0 +1,3 @@
+# 'sup?
+
+See [HOUSE_RULES.md](HOUSE_RULES.md).

--- a/.agents-ctx/TESTING.md
+++ b/.agents-ctx/TESTING.md
@@ -1,0 +1,112 @@
+# Testing
+
+Grounded in the project's own review history and merged commits,
+plus explicit maintainer conventions carried over from other
+projects — not guesses.
+
+## Tests are proof, not decoration
+
+New or changed behavior needs a test demonstrating it, covering the
+cases actually touched (including edge cases like `None`). "I don't
+think there's a proof that this works as intended without tests" is
+a near-verbatim recurring review comment (e.g. PR #756, #786, #790,
+#479, #669, #809). Missing test coverage is the single most common
+reason PRs stall or get closed unmerged in this project.
+
+Justify new tests by what they actually verify, not by the
+coverage number alone. Coverage still matters a lot here --
+`.codecov.yml` already targets 100% for `src/`/`tests/`, and 100%
+coverage is a genuinely useful self-check (e.g. it can catch tests
+that silently start getting skipped in CI). It isn't wired up as a
+required CI check yet, only because of unresolved infra problems
+measuring Cython coverage -- not because it's considered optional.
+The point is: don't game the number -- a test that exercises a
+line without meaningfully checking behavior doesn't count, passing
+or not. The same reasoning-over-metrics standard applies to every
+change, not just tests: infra, packaging, and runtime code all
+need well-reasoned, architecturally sound justification, not just
+a passing check.
+
+## No test classes
+
+Every test in `tests/` is a plain `def test_*` function. There are
+zero `class` definitions anywhere in the test suite, across the
+full project history. Don't introduce `unittest.TestCase`
+subclasses or bare grouping classes.
+
+## Prefer parametrize/fixtures over duplicated test logic
+
+When two tests differ only in their input data, that's a
+parametrized fixture, not two near-identical functions, e.g.
+`@pytest.fixture(params=(32, SFTP_MAX_CHUNK + 1), ids=(...))`.
+Precedent: PR #638 collapses `other_payload`/`large_payload` into
+one parametrized fixture; a project commit merges near-duplicate
+`NOTSET`/`TRACE` tests into a single `@pytest.mark.parametrize`
+case.
+
+Loop-based checks inside a single test are generally a sign the
+test should be parametrized instead. The one accepted exception is
+`pytest-subtests` (the `subtests` fixture), for structured,
+individually reported sub-assertions within one test.
+
+## Real e2e over mocking
+
+`tests/` contains zero uses of `mock`, `Mock`, or `monkeypatch`.
+Every test -- unit and integration alike -- exercises a real
+`sshd` process spun up per-test via the `sshd_addr` fixture in
+`tests/conftest.py`. Don't introduce mocking as a substitute for
+exercising real libssh/sshd behavior.
+
+## Design for testability
+
+Prefer decoupling techniques -- dependency injection in particular
+-- that let code be tested in isolation, over reaching for
+monkeypatching. Monkeypatching (via `unittest.mock` or the
+`monkeypatch` fixture) is only acceptable at real system
+boundaries: the system clock/timezone, environment variables, or
+swapping in a stub server. It's not a substitute for designing
+components to be testable on their own.
+
+## Test layout
+
+Under `tests/unit/`, test files are named `<module>_test.py`, not
+`test_<module>.py`, loosely mirroring `src/pylibsshext/`:
+`channel_test.py`, `session_test.py`, `sftp_test.py`, `scp_test.py`,
+`version_test.py`. The correspondence isn't strict 1:1 (e.g.
+`errors` is covered via `pytest.raises` inside other files, not its
+own file) -- match the existing file when extending it, and only
+add a new `<module>_test.py` for a genuinely new module. This
+module-mirroring convention applies to `tests/unit/` specifically;
+other test categories (e.g. `tests/integration/`) are organized by
+scenario/feature instead, not by source module.
+
+## Tests usually land in the same commit as the behavior they cover
+
+When a change adds or alters behavior, the test change normally
+lands in the *same* atomic commit, not a follow-up -- there's no
+evidence of strict test-first/TDD commit ordering as a project
+ritual. That style of TDD is mainly useful for interactive
+development and exploration, used in tandem with continuous
+adjustment, not as a blanket rule here.
+
+The one accepted exception: a PR that adds only a failing test,
+marked `@pytest.mark.xfail`, can be merged on its own ahead of the
+fix, to be resolved in a follow-up. Don't treat a merged `xfail` as
+done, though -- it's a tracked gap, not a resolution.
+
+## Assertions
+
+Use `pytest.raises(..., match=...)` -- never a bare
+`pytest.raises(SomeError)` -- so the assertion pins down which
+failure is expected, not just its type.
+
+## Filesystem fixtures
+
+Use pytest's built-in `tmp_path` fixture; don't hand-roll
+temp-directory setup/teardown.
+
+## Every test and fixture has a one-line docstring
+
+Describing what it checks or provides, not restating the code,
+e.g. `"""Check that SFTP file transfer works."""`. Enforced by
+`darglint` in CI.

--- a/.gitignore
+++ b/.gitignore
@@ -396,3 +396,6 @@ $RECYCLE.BIN/
 
 # setuptools-scm write_to:
 /src/pylibsshext/_scm_version.py
+
+# Agents
+CLAUDE.local.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENTS.md
+
+> [!important]
+> **Highest priority — do this before anything else:** load
+> @.agents-ctx/HOUSE_RULES.md.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,4 @@
+@~/.claude/ansible/context.md
+@~/.claude/ansible/pylibssh/context.md
+@AGENTS.md
+@CLAUDE.local.md

--- a/docs/changelog-fragments/867.contrib.rst
+++ b/docs/changelog-fragments/867.contrib.rst
@@ -1,0 +1,4 @@
+The repository now has initial infrastructure for pet agents to lurk in and
+understand how to interact with the project in a useful, constructive and
+collaborative manner while being exposed to the same quality development
+tools their humans are -- by :user:`webknjaz`.

--- a/docs/changelog-fragments/README.rst
+++ b/docs/changelog-fragments/README.rst
@@ -17,6 +17,22 @@ related details generates noise that is not particularly useful
 to the end-users most of the time. And so such details should be
 recorded in the Git history rather than a changelog.
 
+A changelog entry is not a restated commit message. It summarizes
+everything that changed *since the previous release* for a wide
+audience of end-users, in plain language and past tense -- while a
+commit message describes the delta *since the immediately
+preceding commit*, for fellow developers and contributors, and is
+conventionally written in the imperative mood ("Add", "Fix") with
+room for full technical detail and motivation. See `Keep a
+Changelog's guidance on commit logs vs changelogs`_ for more on
+this distinction.
+
+Unlike commit history -- which can be reworded, rebased, or
+squashed -- a changelog entry is a permanent historical record. It
+should not be retroactively removed even if the underlying code is
+later reverted: the contribution genuinely happened, and the
+record of it should stand.
+
 -----------------------------------------
 Alright! So how do I add a news fragment?
 -----------------------------------------
@@ -112,3 +128,6 @@ File ``docs/changelog-fragments/57.bugfix.rst``:
 
 .. _Towncrier philosophy:
    https://towncrier.readthedocs.io/en/stable/#philosophy
+
+.. _Keep a Changelog's guidance on commit logs vs changelogs:
+   https://keepachangelog.com/en/1.1.0/#bad-practices


### PR DESCRIPTION
##### SUMMARY

This patch establishes the entry-point chain `CLAUDE.md` -> `AGENTS.md` -> `.agents-ctx/HOUSE_RULES.md`, along with `.agents-ctx/HOUSE_STYLE.md` and a `.gitignore` that restricts `.agents-ctx/` to Markdown files. Together these form the initial scaffolding for the house-style/tribal-knowledge memory that Claude Code and other agentic tools load when working in this repo.

In this patch, `HOUSE_STYLE.md` documents the only rule so far: no new `@`-mention imports below `AGENTS.md`. `@`-syntax loads eagerly at the start of every session regardless of relevance, so letting it spread would pollute the context window; everything past `HOUSE_RULES.md` links out with plain Markdown instead, to be pulled in on demand. This mirrors the approach outlined in [1].

The `.gitignore` also gains a `CLAUDE.local.md` entry, matching how `ansible/ansible` keeps that personal override file untracked.

The naming and idea behind `HOUSE_STYLE.md` come from Bernát Gábor (@gaborbernat), as discussed in the PR thread linked below [2].

[1] https://www.humanlayer.dev/blog/writing-a-good-claude-md
[2] https://github.com/tox-dev/turbohtml/pull/482#discussion_r3551114593

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Infra Pull Request
- Maintenance Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
N/A