### PR TITLE
tests: Use random.bytes for more effective test files creation

### DIFF
--- a/tests/unit/scp_test.py
+++ b/tests/unit/scp_test.py
@@ -2,7 +2,6 @@
 
 import os
 import random
-import string
 
 import pytest
 
@@ -34,10 +33,8 @@ def transmit_payload(request: pytest.FixtureRequest):
     reading/writing.
     """
     payload_len = request.param
-    random_bytes = [
-        ord(random.choice(string.printable)) for _ in range(payload_len)
-    ]
-    return bytes(random_bytes)
+    assert isinstance(payload_len, int)
+    return random.randbytes(payload_len)
 
 
 @pytest.fixture

--- a/tests/unit/sftp_test.py
+++ b/tests/unit/sftp_test.py
@@ -1,7 +1,6 @@
 """Tests suite for sftp."""
 
 import random
-import string
 import uuid
 
 import pytest
@@ -34,10 +33,8 @@ def transmit_payload(request: pytest.FixtureRequest) -> bytes:
     reading/writing.
     """
     payload_len = request.param
-    random_bytes = [
-        ord(random.choice(string.printable)) for _ in range(payload_len)
-    ]
-    return bytes(random_bytes)
+    assert isinstance(payload_len, int)
+    return random.randbytes(payload_len)
 
 
 @pytest.fixture


### PR DESCRIPTION
##### SUMMARY
Previously we used only printable characters for simpler debugging as the implementation used to corrupt files.

The current implementation should no longer corrupt files so readability should not be a concern anymore. We also want to test larger files and their creation will be very inefficient with this code.

##### ISSUE TYPE
- Bugfix Pull Request