### PR TITLE
sftp: Introduce stat() method and provide Attributes class

### DIFF
--- a/docs/changelog-fragments/874.feature.rst
+++ b/docs/changelog-fragments/874.feature.rst
@@ -1,0 +1,5 @@
+Added new API ``SFTP.stat()`` to gather information about remote files.
+The attributes are accessed through new object ``SFTP.Attributes``,
+handling all supported SFTPv3 attributes. Additionally, this introduces
+a new helper API ``SFTP.version()`` returning the negotiated SFTP protocol
+version -- by :user:`Jakuje`.

--- a/src/pylibsshext/includes/sftp.pxd
+++ b/src/pylibsshext/includes/sftp.pxd
@@ -72,9 +72,29 @@ cdef extern from "libssh/sftp.h" nogil:
     cdef int SSH_FX_WRITE_PROTECT
     cdef int SSH_FX_NO_MEDIA
 
+    cdef int SSH_FILEXFER_TYPE_REGULAR
+    cdef int SSH_FILEXFER_TYPE_DIRECTORY
+    cdef int SSH_FILEXFER_TYPE_SYMLINK
+    cdef int SSH_FILEXFER_TYPE_SPECIAL
+    cdef int SSH_FILEXFER_TYPE_UNKNOWN
+
+    cdef int SSH_FILEXFER_ATTR_SIZE
+    cdef int SSH_FILEXFER_ATTR_PERMISSIONS
+    cdef int SSH_FILEXFER_ATTR_ACCESSTIME
+    cdef int SSH_FILEXFER_ATTR_ACMODTIME
+    cdef int SSH_FILEXFER_ATTR_CREATETIME
+    cdef int SSH_FILEXFER_ATTR_MODIFYTIME
+    cdef int SSH_FILEXFER_ATTR_ACL
+    cdef int SSH_FILEXFER_ATTR_OWNERGROUP
+    cdef int SSH_FILEXFER_ATTR_SUBSECOND_TIMES
+    cdef int SSH_FILEXFER_ATTR_EXTENDED
+    cdef int SSH_FILEXFER_ATTR_UIDGID
+
     sftp_session sftp_new(ssh_session session)
     int sftp_init(sftp_session sftp)
     void sftp_free(sftp_session sftp)
+
+    int sftp_server_version(sftp_session sftp)
 
     sftp_file sftp_open(sftp_session session, const char *file, int accesstype, mode_t mode)
     int sftp_close(sftp_file file)
@@ -83,6 +103,8 @@ cdef extern from "libssh/sftp.h" nogil:
     int sftp_get_error(sftp_session sftp)
 
     sftp_attributes sftp_stat(sftp_session session, const char *path)
+
+    void sftp_attributes_free(sftp_attributes file)
 
 
 cdef extern from "sys/stat.h" nogil:

--- a/src/pylibsshext/sftp.pxd
+++ b/src/pylibsshext/sftp.pxd
@@ -23,3 +23,10 @@ from pylibsshext.session cimport Session
 cdef class SFTP:
     cdef Session session
     cdef sftp.sftp_session _libssh_sftp_session
+
+cdef class Attributes:
+    cdef sftp.sftp_attributes attrs
+    cdef int version
+
+    @staticmethod
+    cdef Attributes _from_ptr(sftp.sftp_attributes ptr, int version)

--- a/src/pylibsshext/sftp.pyx
+++ b/src/pylibsshext/sftp.pyx
@@ -15,6 +15,8 @@
 # License along with this library; if not, see file LICENSE.rst in this
 # repository.
 
+import os
+
 from posix.fcntl cimport O_CREAT, O_RDONLY, O_TRUNC, O_WRONLY
 
 from cpython.mem cimport PyMem_Free, PyMem_Malloc
@@ -27,6 +29,8 @@ from pylibsshext.session cimport get_libssh_session
 # The value 32kB is a safe fallback when we cannot determine better value from
 # the server, for example using limits@openssh.com (since libssh 0.11.0).
 SFTP_MAX_CHUNK = 32_768
+
+_NO_ATTR_ERR = "The attribute {attr_name} is not available"
 
 
 MSG_MAP = {
@@ -59,6 +63,49 @@ cdef class SFTP:
             sftp.sftp_free(self._libssh_sftp_session)
             self._libssh_sftp_session = NULL
 
+    @property
+    def version(self) -> int:
+        """
+        The SFTP protocol version.
+
+        The most common protocol version is version 3 implemenbed by OpenSSH. The libssh
+        implements also some parts of version 4 which is partially incompatible with the
+        previous versions.
+        """
+        return sftp.sftp_server_version(self._libssh_sftp_session)
+
+    def stat(self, remote_path: str | os.PathLike[str]) -> Attributes:
+        """
+        Requests information about remote file or directory.
+
+        Requests information about file or directory from the remote server.
+        This information includes its size, owner, group, type and many more.
+
+        :param remote_path: The remote file or directory to find information about
+
+        :raises LibsshSFTPException: If operation failed.
+
+        :return: Remote file or directory attributes
+        """
+        cdef sftp.sftp_attributes attrs
+
+        remote_path_b = os.fspath(remote_path)
+        if isinstance(remote_path_b, str):
+            remote_path_b = remote_path_b.encode("utf-8")
+        else:
+            raise TypeError(f"Expected str or os.PathLike, got {type(remote_path).__name__}")
+
+        attrs = sftp.sftp_stat(self._libssh_sftp_session, remote_path_b)
+        if attrs is NULL:
+            raise LibsshSFTPException(
+                "Failed to stat the remote file [%s]. Error: [%s]"
+                % (
+                    remote_path,
+                    self._get_sftp_error_str(),
+                ),
+            )
+        return Attributes._from_ptr(attrs, self.version)
+
     def put(self, local_file, remote_file):
         """
         Upload local file to remote server.
@@ -87,7 +134,7 @@ cdef class SFTP:
                     "Opening remote file [%s] for write failed with error [%s]"
                     % (
                         remote_file,
-                        self._get_sftp_error_str()
+                        self._get_sftp_error_str(),
                     ),
                 )
             read_buffer = f.read(SFTP_MAX_CHUNK)
@@ -120,21 +167,12 @@ cdef class SFTP:
         """
         cdef sftp.sftp_file rf
         cdef char *read_buffer = NULL
-        cdef sftp.sftp_attributes attrs
 
         remote_file_b = remote_file
         if isinstance(remote_file_b, unicode):
             remote_file_b = remote_file.encode("utf-8")
 
-        attrs = sftp.sftp_stat(self._libssh_sftp_session, remote_file_b)
-        if attrs is NULL:
-            raise LibsshSFTPException(
-                "Failed to stat the remote file [%s]. Error: [%s]"
-                % (
-                    remote_file,
-                    self._get_sftp_error_str(),
-                ),
-            )
+        attrs = self.stat(remote_file)
         file_size = attrs.size
 
         rf = sftp.sftp_open(self._libssh_sftp_session, remote_file_b, O_RDONLY, sftp.S_IRWXU)
@@ -198,3 +236,178 @@ cdef class SFTP:
         if error in MSG_MAP and error != sftp.SSH_FX_FAILURE:
             return MSG_MAP[error]
         return "Generic failure: %s" % self.session._get_session_error_str()
+
+
+cdef class Attributes:
+    """
+    SFTP Attributes providing information about remote file.
+
+    Note, that not all the information is always available (see the doc string describing availability).
+    Unavailable properties raise LookupError exception.
+    """
+
+    @staticmethod
+    cdef Attributes _from_ptr(sftp.sftp_attributes ptr, int version):
+        """Create a new object from a raw C pointer."""
+        if ptr is NULL:
+            raise LibsshSFTPException("Can not construct Attributes from NULL")
+
+        cdef Attributes obj = Attributes.__new__(Attributes)
+        obj.attrs = ptr
+        obj.version = version
+        return obj
+
+    def __dealloc__(self):
+        if self.attrs is NULL:
+            return
+
+        sftp.sftp_attributes_free(self.attrs)
+        self.attrs = NULL
+
+    @property
+    def name(self) -> str:
+        """
+        The file name.
+
+        Note, that this attribute is not set when Attributes come from stat().
+        """
+        if self.attrs.name is NULL:
+            raise LookupError(_NO_ATTR_ERR.format(attr_name='name'))
+        return self.attrs.name.decode('utf-8')
+
+    @property
+    def longname(self) -> str:
+        """
+        The extended name (i. e. output of `ls -l`).
+
+        Note, that this attribute is not set when Attributes come from stat().
+        This is set only since SFTP protocol version 3 with OpenSSH.
+        """
+        if self.attrs.longname is NULL:
+            raise LookupError(_NO_ATTR_ERR.format(attr_name='longname'))
+        return self.attrs.longname.decode('utf-8')
+
+    @property
+    def owner(self) -> str:
+        """
+        The file owner.
+
+        Note, that this attribute is not set when Attributes come from stat().
+        This is set only since SFTP protocol version 4 or with OpenSSH.
+        """
+        if self.attrs.flags & sftp.SSH_FILEXFER_ATTR_OWNERGROUP == 0 or self.attrs.owner is NULL:
+            raise LookupError(_NO_ATTR_ERR.format(attr_name='owner'))
+        return self.attrs.owner.decode('utf-8')
+
+    @property
+    def group(self) -> str:
+        """
+        The file group.
+
+        Note, that this attribute is not set when Attributes come from stat().
+        This is set only since SFTP protocol version 4 or with OpenSSH.
+        """
+        if self.attrs.flags & sftp.SSH_FILEXFER_ATTR_OWNERGROUP == 0 or self.attrs.group is NULL:
+            raise LookupError(_NO_ATTR_ERR.format(attr_name='group'))
+        return self.attrs.group.decode('utf-8')
+
+    @property
+    def is_regular(self) -> bool:
+        """
+        Attribute representing whether the object is a regular file or not.
+        """
+        return self.attrs.type == sftp.SSH_FILEXFER_TYPE_REGULAR
+
+    @property
+    def is_dir(self) -> bool:
+        """
+        Attribute representing whether the object is a directory or not.
+        """
+        return self.attrs.type == sftp.SSH_FILEXFER_TYPE_DIRECTORY
+
+    @property
+    def is_symlink(self) -> bool:
+        """
+        Attribute representing whether the object is a symlink or not.
+        """
+        return self.attrs.type == sftp.SSH_FILEXFER_TYPE_SYMLINK
+
+    @property
+    def is_special(self) -> bool:
+        """
+        Attribute representing whether the object is a special file or not.
+        """
+        return self.attrs.type == sftp.SSH_FILEXFER_TYPE_SPECIAL
+
+    @property
+    def is_unknown(self) -> bool:
+        """
+        Attribute representing whether the object is an unknown file type or not.
+        """
+        return self.attrs.type == sftp.SSH_FILEXFER_TYPE_UNKNOWN
+
+    @property
+    def size(self) -> int:
+        """
+        The file size.
+
+        This is set only with SSH_FILEXFER_ATTR_SIZE flag
+        """
+        if self.attrs.flags & sftp.SSH_FILEXFER_ATTR_SIZE == 0:
+            raise LookupError(_NO_ATTR_ERR.format(attr_name='size'))
+        return self.attrs.size
+
+    @property
+    def uid(self) -> int:
+        """
+        The numerical user ID of the file owner.
+
+        This is set only with SSH_FILEXFER_ATTR_UIDGID flag
+        """
+        if self.attrs.flags & sftp.SSH_FILEXFER_ATTR_UIDGID == 0:
+            raise LookupError(_NO_ATTR_ERR.format(attr_name='uid'))
+        return self.attrs.uid
+
+    @property
+    def gid(self) -> int:
+        """
+        The numerical group ID of the file group.
+
+        This is set only with SSH_FILEXFER_ATTR_UIDGID flag
+        """
+        if self.attrs.flags & sftp.SSH_FILEXFER_ATTR_UIDGID == 0:
+            raise LookupError(_NO_ATTR_ERR.format(attr_name='gid'))
+        return self.attrs.gid
+
+    @property
+    def permissions(self) -> int:
+        """
+        The numerical file permissions as returned by stat().
+
+        This is set only with SSH_FILEXFER_ATTR_PERMISSIONS flag
+        """
+        if self.attrs.flags & sftp.SSH_FILEXFER_ATTR_PERMISSIONS == 0:
+            raise LookupError(_NO_ATTR_ERR.format(attr_name='permissions'))
+        return self.attrs.permissions
+
+    @property
+    def atime(self) -> int:
+        """
+        The file access time.
+
+        This is set only in SFTP protocol version 3 with SSH_FILEXFER_ATTR_ACMODTIME flag
+        """
+        if self.attrs.flags & sftp.SSH_FILEXFER_ATTR_ACMODTIME == 0:
+            raise LookupError(_NO_ATTR_ERR.format(attr_name='atime'))
+        return self.attrs.atime
+
+    @property
+    def mtime(self) -> int:
+        """
+        The file modification time.
+
+        This is set only in SFTP protocol version 3 with SSH_FILEXFER_ATTR_ACMODTIME flag
+        """
+        if self.attrs.flags & sftp.SSH_FILEXFER_ATTR_ACMODTIME == 0:
+            raise LookupError(_NO_ATTR_ERR.format(attr_name='mtime'))
+        return self.attrs.mtime

--- a/tests/unit/sftp_test.py
+++ b/tests/unit/sftp_test.py
@@ -1,18 +1,20 @@
 """Tests suite for sftp."""
 
+import os
 import random
 import uuid
 
 import pytest
 
-from pylibsshext.sftp import SFTP_MAX_CHUNK
+from pylibsshext.errors import LibsshSFTPException
+from pylibsshext.sftp import SFTP, SFTP_MAX_CHUNK
 
 
 SMALL_PAYLOAD = 32
 
 
 @pytest.fixture
-def sftp_session(ssh_client_session):
+def sftp_session(ssh_client_session) -> SFTP:
     """Initialize an SFTP session and destroy it after testing."""
     sftp_sess = ssh_client_session.sftp()
     try:  # noqa: WPS501
@@ -113,6 +115,11 @@ def test_get_existing(
     assert pre_existing_dst_path.read_bytes() == transmit_payload
 
 
+def test_sftp_version(sftp_session):
+    """Check that SFTP protocol version (reported by OpenSSH server) is 3."""
+    assert sftp_session.version == 3
+
+
 def test_put_existing(
     pre_existing_dst_path,
     src_path,
@@ -122,3 +129,86 @@ def test_put_existing(
     """Check that SFTP file upload works when target file exists."""
     sftp_session.put(str(src_path), str(pre_existing_dst_path))
     assert pre_existing_dst_path.read_bytes() == transmit_payload
+
+
+@pytest.fixture
+def existing_path(tmp_path, transmit_payload):
+    """Return a file path that exist and has given size."""
+    path = tmp_path / 'test-file.txt'
+    path.write_bytes(transmit_payload)
+    return path
+
+
+def test_stat_existing(  # noqa: WPS218
+    existing_path: os.PathLike,
+    transmit_payload: bytes,
+    sftp_session: SFTP,
+):
+    """Check the stat returns the right file information."""
+    si = existing_path.stat()
+
+    attrs = sftp_session.stat(str(existing_path))
+    assert attrs.size == len(transmit_payload)
+    assert attrs.size == si.st_size
+    assert attrs.mtime == int(si.st_mtime)
+    assert attrs.atime == int(si.st_atime)
+    assert attrs.permissions == si.st_mode
+    assert attrs.uid == si.st_uid
+    assert attrs.gid == si.st_gid
+
+    # file type
+    assert attrs.is_regular
+    props = ('is_dir', 'is_symlink', 'is_special', 'is_unknown')
+    for prop in props:
+        assert not getattr(attrs, prop)
+
+
+# These will work only with other operation than stat
+@pytest.mark.parametrize(
+    'attribute',
+    (
+        'name',
+        'longname',
+        'owner',
+        'group',
+    ),
+)
+def test_stat_unsupported(
+    existing_path: os.PathLike,
+    sftp_session: SFTP,
+    attribute: str,
+) -> None:
+    """Check the unsupported attributes are reported correctly."""
+    msg = rf'^The attribute {attribute} is not available$'
+    attrs = sftp_session.stat(existing_path)
+    with pytest.raises(LookupError, match=msg):
+        getattr(attrs, attribute)
+
+
+def test_stat_bytes(
+    existing_path: os.PathLike,
+    sftp_session: SFTP,
+) -> None:
+    """Check the unsupported attributes are reported correctly."""
+    error_msg = r'^Expected str or os.PathLike, got bytes$'
+    path_b = str(existing_path).encode('utf-8')
+    with pytest.raises(TypeError, match=error_msg):
+        sftp_session.stat(path_b)
+
+
+@pytest.fixture
+def non_existing_path(tmp_path) -> os.PathLike:
+    """Return a path that is guaranteed to not exist."""
+    return tmp_path / 'no-file-here.txt'
+
+
+def test_stat_non_existing(
+    non_existing_path: os.PathLike,
+    sftp_session: SFTP,
+) -> None:
+    """Check the stat raises exception on non-existing file."""
+    error_msg = rf'^Failed to stat the remote file \[{non_existing_path}\]. Error: \[File doesn\'t exist\]$'
+    with pytest.raises(LibsshSFTPException, match=error_msg):
+        sftp_session.stat(non_existing_path)
+    with pytest.raises(LibsshSFTPException, match=error_msg):
+        sftp_session.stat(str(non_existing_path))


### PR DESCRIPTION
##### SUMMARY
The stat was used only internally so far and managing its life-cycle was problematic leading to memory leaks.

This change is introducing separate stat() API and Attributes class carying all the SFTP attributes visible to the caller and managing underlying C-structure lifetime.

##### ISSUE TYPE
- Feature Pull Request