### PR TITLE
Remove use of CPython internal PyBytes_AS_STRING API

### DIFF
--- a/docs/changelog-fragments/875.breaking.rst
+++ b/docs/changelog-fragments/875.breaking.rst
@@ -1,0 +1,6 @@
+Changed the ``Channel.write()`` API to accept only :class:`bytes` type.
+Previously, this API used to accept anything that could have been converted
+to a pointer using :c:func:`PyBytes_AS_STRING` and that would implement
+:meth:`~object.__len__()` interface, which could result in unexpected behavior
+even for UTF8 strings. Anything else than :class:`bytes` now raises
+:exc:`TypeError` -- by :user:`Jakuje`.

--- a/docs/changelog-fragments/875.misc.rst
+++ b/docs/changelog-fragments/875.misc.rst
@@ -1,0 +1,3 @@
+Removed the needless use of CPython internal API
+:c:func:`PyBytes_AS_STRING` throughout the code to simplify code
+and improve the compatibility with limited Python API -- by :user:`Jakuje`.

--- a/src/pylibsshext/channel.pyx
+++ b/src/pylibsshext/channel.pyx
@@ -19,7 +19,6 @@ import signal
 import time
 from io import BytesIO
 
-from cpython.bytes cimport PyBytes_AS_STRING
 from libc.string cimport memset
 
 from pylibsshext.errors cimport LibsshChannelException
@@ -126,7 +125,8 @@ cdef class Channel:
         return self.read_nonblocking(size=size, stderr=stderr)
 
     def write(self, data):
-        written = libssh.ssh_channel_write(self._libssh_channel, PyBytes_AS_STRING(data), len(data))
+        cdef const char* c_buf = data
+        written = libssh.ssh_channel_write(self._libssh_channel, c_buf, len(data))
         if written == libssh.SSH_ERROR:
             raise LibsshChannelException("Failed to write to ssh channel")
         return written

--- a/src/pylibsshext/channel.pyx
+++ b/src/pylibsshext/channel.pyx
@@ -124,8 +124,16 @@ cdef class Channel:
     def recv(self, size=1024, stderr=0):
         return self.read_nonblocking(size=size, stderr=stderr)
 
-    def write(self, data):
+    def write(self, data: bytes) -> int:
+        """
+        Write data to the SSH channel.
+
+        :param data: The payload to write to the channel
+
+        :return: Number of bytes written
+        """
         cdef const char* c_buf = data
+
         written = libssh.ssh_channel_write(self._libssh_channel, c_buf, len(data))
         if written == libssh.SSH_ERROR:
             raise LibsshChannelException("Failed to write to ssh channel")

--- a/src/pylibsshext/scp.pyx
+++ b/src/pylibsshext/scp.pyx
@@ -90,7 +90,7 @@ cdef class SCP:
                     c_buf = read_buffer
 
                     # Write to the open file
-                    rc = libssh.ssh_scp_write(scp, c_buf, read_bytes)
+                    rc = libssh.ssh_scp_write(scp, c_buf, len(read_buffer))
                     if rc != libssh.SSH_OK:
                         raise LibsshSCPException("Can't write to remote file: %s" % self._get_ssh_error_str())
                     remaining_bytes_to_read -= read_bytes

--- a/src/pylibsshext/scp.pyx
+++ b/src/pylibsshext/scp.pyx
@@ -17,7 +17,6 @@
 
 import os
 
-from cpython.bytes cimport PyBytes_AS_STRING
 from cpython.mem cimport PyMem_Free, PyMem_Malloc
 
 from pylibsshext.errors cimport LibsshSCPException
@@ -42,6 +41,7 @@ cdef class SCP:
         :param remote_file: The path on the remote host where the file should be placed
         :type remote_file: str
         """
+        cdef const char* c_buf
         remote_file_b = remote_file
         if isinstance(remote_file_b, unicode):
             remote_file_b = remote_file.encode("utf-8")
@@ -87,9 +87,10 @@ cdef class SCP:
                     # Read the chunk from local file
                     read_bytes = min(remaining_bytes_to_read, read_buffer_size)
                     read_buffer = f.read(read_bytes)
+                    c_buf = read_buffer
 
                     # Write to the open file
-                    rc = libssh.ssh_scp_write(scp, PyBytes_AS_STRING(read_buffer), read_bytes)
+                    rc = libssh.ssh_scp_write(scp, c_buf, read_bytes)
                     if rc != libssh.SSH_OK:
                         raise LibsshSCPException("Can't write to remote file: %s" % self._get_ssh_error_str())
                     remaining_bytes_to_read -= read_bytes

--- a/src/pylibsshext/session.pyx
+++ b/src/pylibsshext/session.pyx
@@ -175,9 +175,14 @@ cdef class Session(object):
             value_long = value
             libssh.ssh_options_set(self._libssh_session, key_m, &value_long)
         else:
+            # We need to keep temporary python variable before assigning it
+            # to c pointer, otherwise GC would collect the object and we
+            # would crash on use-after-free
+            # https://cython.readthedocs.io/en/latest/src/tutorial/strings.html#encoding-text-to-bytes
+            value_b = value
             if isinstance(value, str):
-                value = value.encode("utf-8")
-            c_buf = value
+                value_b = value.encode("utf-8")
+            c_buf = value_b
             libssh.ssh_options_set(self._libssh_session, key_m, c_buf)
             if key in OPTS_DIR_MAP:
                 self._opts[key] = value

--- a/src/pylibsshext/session.pyx
+++ b/src/pylibsshext/session.pyx
@@ -175,7 +175,7 @@ cdef class Session(object):
             value_long = value
             libssh.ssh_options_set(self._libssh_session, key_m, &value_long)
         else:
-            if isinstance(value, basestring):
+            if isinstance(value, str):
                 value = value.encode("utf-8")
             c_buf = value
             libssh.ssh_options_set(self._libssh_session, key_m, c_buf)

--- a/src/pylibsshext/session.pyx
+++ b/src/pylibsshext/session.pyx
@@ -17,8 +17,6 @@
 import inspect
 import logging
 
-from cpython.bytes cimport PyBytes_AS_STRING
-
 from pylibsshext.channel import Channel
 from pylibsshext.errors cimport LibsshSessionException
 from pylibsshext.logging import _initialize_logging, _set_level
@@ -158,6 +156,7 @@ cdef class Session(object):
         cdef int value_int
         cdef unsigned int value_uint
         cdef long value_long
+        cdef const char* c_buf
 
         key_m = None
         if key in OPTS_DIR_MAP:
@@ -178,7 +177,8 @@ cdef class Session(object):
         else:
             if isinstance(value, basestring):
                 value = value.encode("utf-8")
-            libssh.ssh_options_set(self._libssh_session, key_m, PyBytes_AS_STRING(value))
+            c_buf = value
+            libssh.ssh_options_set(self._libssh_session, key_m, c_buf)
             if key in OPTS_DIR_MAP:
                 self._opts[key] = value
 

--- a/src/pylibsshext/sftp.pyx
+++ b/src/pylibsshext/sftp.pyx
@@ -17,7 +17,6 @@
 
 from posix.fcntl cimport O_CREAT, O_RDONLY, O_TRUNC, O_WRONLY
 
-from cpython.bytes cimport PyBytes_AS_STRING
 from cpython.mem cimport PyMem_Free, PyMem_Malloc
 
 from pylibsshext.errors cimport LibsshSFTPException
@@ -71,6 +70,7 @@ cdef class SFTP:
         :type remote_file: str or bytes
         """
         cdef sftp.sftp_file rf
+        cdef const char* c_buf
         with open(local_file, "rb") as f:
             remote_file_b = remote_file
             if isinstance(remote_file_b, unicode):
@@ -93,8 +93,9 @@ cdef class SFTP:
             read_buffer = f.read(SFTP_MAX_CHUNK)
 
             while read_buffer != b"":
+                c_buf = read_buffer
                 length = len(read_buffer)
-                written = sftp.sftp_write(rf, PyBytes_AS_STRING(read_buffer), length)
+                written = sftp.sftp_write(rf, c_buf, length)
                 if written != length:
                     sftp.sftp_close(rf)
                     raise LibsshSFTPException(

--- a/tests/unit/channel_test.py
+++ b/tests/unit/channel_test.py
@@ -1,11 +1,13 @@
 """Tests suite for channel."""
 
 import gc
+import pathlib
 import signal
 import time
 
 import pytest
 
+from pylibsshext.channel import Channel
 from pylibsshext.errors import LibsshChannelException
 from pylibsshext.session import Session
 
@@ -195,6 +197,45 @@ def test_is_eof(ssh_channel):
     ssh_channel.request_exec('exit 0')
     ssh_channel.poll(timeout=POLL_TIMEOUT)
     assert ssh_channel.is_eof
+
+
+@pytest.fixture
+def server_side_tmp_file_path(tmp_path: pathlib.Path) -> pathlib.Path:
+    """Create a new unique path that can be written."""
+    return tmp_path / 'test-file.txt'
+
+
+@pytest.fixture
+def _remote_tmp_file_data_writer(
+    server_side_tmp_file_path: pathlib.Path,
+    ssh_channel: Channel,
+) -> None:
+    """Run a server-side process writing network-received bytes to disk."""
+    ssh_channel.request_exec(f'cat > {server_side_tmp_file_path}')
+
+
+@pytest.mark.usefixtures('_remote_tmp_file_data_writer')
+def test_write_bytes(
+    server_side_tmp_file_path: pathlib.Path,
+    ssh_channel: Channel,
+) -> None:
+    """Test that write() takes bytes correctly."""
+    data_to_write = b'just pure ASCII bytes'
+    ssh_channel.write(data_to_write)
+    ssh_channel.send_eof()
+    ssh_channel.poll(timeout=POLL_TIMEOUT)
+    assert server_side_tmp_file_path.read_bytes() == data_to_write
+
+
+@pytest.mark.usefixtures('_remote_tmp_file_data_writer')
+def test_write_utf8_str(ssh_channel: Channel) -> None:
+    """Test that write() rejects non-bytes."""
+    data_to_write = '∮ E⋅da = Q,  n → ∞, ∑ f(i)'
+    error_msg = (
+        r"^Argument 'data' has incorrect type \(expected bytes, got str\)$"
+    )
+    with pytest.raises(TypeError, match=error_msg):
+        ssh_channel.write(data_to_write)
 
 
 def test_destructor(ssh_session_connect):


### PR DESCRIPTION
##### SUMMARY

The CPython API PyBytes_AS_STRING is needed only when writing Python C Extensions in pure C. In CPython, this is handled automatically.

This is requirement for #819 (compiling with limited API).

##### ISSUE TYPE
- Misc Pull Request