### PR TITLE
ci: Add ubi 9.8 CI target

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -958,6 +958,8 @@ jobs:
           registry: registry.access.redhat.com
         - tag: ubi9/ubi:9.7
           registry: registry.access.redhat.com
+        - tag: ubi9/ubi:9.8
+          registry: registry.access.redhat.com
         - tag: centos/centos:stream9
           registry: quay.io
         - tag: centos/centos:stream10

--- a/docs/changelog-fragments/876.contrib.rst
+++ b/docs/changelog-fragments/876.contrib.rst
@@ -1,0 +1,1 @@
+Added the UBI 9.8 container image to the CI test matrix -- by :user:`Jakuje`.


### PR DESCRIPTION
##### SUMMARY
Extend test coverage on latest ubi9 container image.

##### ISSUE TYPE
- CI Improvement