### PR TITLE
sftp: Handle remote file opening in context manager

### DIFF
--- a/docs/changelog-fragments/879.bugfix.rst
+++ b/docs/changelog-fragments/879.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed memory leaks of remote file descriptors inside ``get()`` and ``put()``
+methods in ``SFTP`` by replacing the manual memory handling with a context
+manager -- by :user:`Jakuje`.

--- a/src/pylibsshext/sftp.pxd
+++ b/src/pylibsshext/sftp.pxd
@@ -23,3 +23,8 @@ from pylibsshext.session cimport Session
 cdef class SFTP:
     cdef Session session
     cdef sftp.sftp_session _libssh_sftp_session
+
+cdef class _RemoteFile:
+    cdef sftp.sftp_file _fd
+    cdef SFTP _sftp
+    cdef _path

--- a/src/pylibsshext/sftp.pyx
+++ b/src/pylibsshext/sftp.pyx
@@ -17,7 +17,11 @@
 
 from posix.fcntl cimport O_CREAT, O_RDONLY, O_TRUNC, O_WRONLY
 
-from cpython.mem cimport PyMem_Free, PyMem_Malloc
+import typing as _t  # noqa: WPS111
+
+
+if _t.TYPE_CHECKING:  # pragma: no cover
+    from types import TracebackType
 
 from pylibsshext.errors cimport LibsshSFTPException
 from pylibsshext.session cimport get_libssh_session
@@ -69,44 +73,20 @@ cdef class SFTP:
         :param remote_file: The path to upload the file on the remote system
         :type remote_file: str or bytes
         """
-        cdef sftp.sftp_file rf
-        cdef const char* c_buf
-        with open(local_file, "rb") as f:
-            remote_file_b = remote_file
-            if isinstance(remote_file_b, unicode):
-                remote_file_b = remote_file.encode("utf-8")
+        cdef bytearray write_buffer = bytearray(SFTP_MAX_CHUNK)
 
-            rf = sftp.sftp_open(
-                self._libssh_sftp_session,
-                remote_file_b,
-                O_WRONLY | O_CREAT | O_TRUNC,
-                sftp.S_IRWXU,
-            )
-            if rf is NULL:
-                raise LibsshSFTPException(
-                    "Opening remote file [%s] for write failed with error [%s]"
-                    % (
-                        remote_file,
-                        self._get_sftp_error_str()
-                    ),
-                )
-            read_buffer = f.read(SFTP_MAX_CHUNK)
+        with open(local_file, "rb") as local_fd, _RemoteFile(
+            sftp_obj=self,
+            path=remote_file,
+            flags=O_WRONLY | O_CREAT | O_TRUNC,
+        ) as remote_fd:
+            while True:
+                bytes_read = local_fd.readinto(write_buffer)
+                is_eof = bytes_read == 0
+                if is_eof:
+                    break
 
-            while read_buffer != b"":
-                c_buf = read_buffer
-                length = len(read_buffer)
-                written = sftp.sftp_write(rf, c_buf, length)
-                if written != length:
-                    sftp.sftp_close(rf)
-                    raise LibsshSFTPException(
-                        "Writing to remote file [%s] failed with error [%s]"
-                        % (
-                            remote_file,
-                            self._get_sftp_error_str(),
-                        )
-                    )
-                read_buffer = f.read(SFTP_MAX_CHUNK)
-            sftp.sftp_close(rf)
+                remote_fd.write(write_buffer, bytes_read)
 
     def get(self, remote_file, local_file):
         """
@@ -118,8 +98,6 @@ cdef class SFTP:
         :param local_file: The path on the local file system to place the downloaded file
         :type local_file: str or os.PathLike
         """
-        cdef sftp.sftp_file rf
-        cdef char *read_buffer = NULL
         cdef sftp.sftp_attributes attrs
 
         remote_file_b = remote_file
@@ -136,57 +114,28 @@ cdef class SFTP:
                 ),
             )
         file_size = attrs.size
+        buffer_size = min(SFTP_MAX_CHUNK, file_size)
+        cdef bytearray read_buffer = bytearray(buffer_size)
+        buffer_view = memoryview(read_buffer)
 
-        rf = sftp.sftp_open(self._libssh_sftp_session, remote_file_b, O_RDONLY, sftp.S_IRWXU)
-        if rf is NULL:
-            raise LibsshSFTPException(
-                "Opening remote file [%s] for read failed with error [%s]"
-                % (
-                    remote_file,
-                    self._get_sftp_error_str(),
-                ),
-            )
+        with _RemoteFile(
+            sftp_obj=self,
+            path=remote_file,
+            flags=O_RDONLY,
+        ) as remote_fd, open(local_file, 'wb') as local_fd:
+            while True:
+                file_data = remote_fd.read(read_buffer)
+                is_eof = file_data == 0
+                if is_eof:
+                    break
 
-        try:
-            with open(local_file, 'wb') as f:
-                buffer_size = min(SFTP_MAX_CHUNK, file_size)
-                read_buffer = <char *>PyMem_Malloc(buffer_size)
-                if read_buffer is NULL:
-                    raise LibsshSFTPException("Memory allocation error")
-
-                while True:
-                    file_data = sftp.sftp_read(rf, <void *>read_buffer, sizeof(char) * buffer_size)
-                    if file_data == 0:
-                        break
-                    elif file_data < 0:
-                        sftp.sftp_close(rf)
-                        raise LibsshSFTPException(
-                            "Reading data from remote file [%s] failed with error [%s]"
-                            % (
-                                remote_file,
-                                self._get_sftp_error_str(),
-                            ),
-                        )
-
-                    bytes_written = f.write(read_buffer[:file_data])
-                    if bytes_written and file_data != bytes_written:
-                        sftp.sftp_close(rf)
-                        raise LibsshSFTPException(
-                            "Number of bytes [%s] read from remote file [%s]"
-                            " does not match number of bytes [%s] written to"
-                            " local file [%s] due to error [%s]"
-                            % (
-                                file_data,
-                                remote_file,
-                                bytes_written,
-                                local_file,
-                                self._get_sftp_error_str(),
-                            ),
-                        )
-        finally:
-            if read_buffer is not NULL:
-                PyMem_Free(read_buffer)
-        sftp.sftp_close(rf)
+                bytes_written = local_fd.write(buffer_view[:file_data])
+                if bytes_written and file_data != bytes_written:
+                    raise LibsshSFTPException(
+                        f"Number of bytes [{file_data}] read from remote file "
+                        f"[{remote_file!s}] does not match number of bytes "
+                        f"[{bytes_written}] written to local file [{local_file!s}]"
+                    )
 
     def close(self):
         if self._libssh_sftp_session is not NULL:
@@ -198,3 +147,90 @@ cdef class SFTP:
         if error in MSG_MAP and error != sftp.SSH_FX_FAILURE:
             return MSG_MAP[error]
         return "Generic failure: %s" % self.session._get_session_error_str()
+
+
+cdef class _RemoteFile:
+    """
+    Remote file handle facade.
+
+    Implements a standard context manager interface for
+    convenient access lifetime management.
+    """
+    def __cinit__(self, *, sftp_obj: SFTP, path: str | bytes, int flags) -> None:
+        self._sftp = sftp_obj
+        self._path = path
+        b_path = path
+        if isinstance(b_path, str):
+            b_path = path.encode("utf-8")
+
+        self._fd = sftp.sftp_open(
+            sftp_obj._libssh_sftp_session,
+            b_path,
+            flags,
+            sftp.S_IRWXU,
+        )
+        if self._fd is not NULL:
+            return
+
+        file_open_mode = "writing" if flags & O_WRONLY else "reading"
+        sftp_error = sftp_obj._get_sftp_error_str()
+        raise LibsshSFTPException(
+            f"Opening remote file [{path!s}] for {file_open_mode!s} "
+            f"failed with error [{sftp_error!s}]",
+        )
+
+    def write(self, data: bytearray, length: int) -> int:
+        """
+        Writes a bytearray directly to the remote file.
+
+        :raises LibsshSessionException: When writing failed or wrong amount of data was written.
+        """
+        cdef const char* c_buf = data
+        written = sftp.sftp_write(self._fd, c_buf, length)
+        if written == length:
+            return written
+
+        sftp_error = self._sftp._get_sftp_error_str()
+        raise LibsshSFTPException(
+            f"Writing to remote file [{self._path!s}] failed with error [{sftp_error}]"
+        )
+
+    def read(self, data: bytearray) -> int:
+        """
+        Reads data from the remote file descriptor into provided bytearray.
+
+        :raises LibsshSessionException: When reading failed.
+        """
+        cdef char* c_buf = data
+        cdef size_t length = len(data)
+
+        file_data = sftp.sftp_read(self._fd, c_buf, length)
+        if file_data >= 0:
+            return file_data
+
+        sftp_error = self._sftp._get_sftp_error_str()
+        raise LibsshSFTPException(
+            f"Reading data from remote file [{self._path!s}] failed with error [{sftp_error!s}]"
+        )
+
+    def __dealloc__(self) -> None:
+        if self._fd is NULL:
+            return
+
+        sftp.sftp_close(self._fd)
+        self._fd = NULL
+
+    def __enter__(self) -> _t.Self:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> bool | None:
+        if self._fd is NULL:
+            return False
+
+        sftp.sftp_close(self._fd)
+        self._fd = NULL

--- a/tests/unit/sftp_test.py
+++ b/tests/unit/sftp_test.py
@@ -1,11 +1,20 @@
 """Tests suite for sftp."""
 
+from __future__ import annotations
+
+import os
 import random
+import typing as _t  # noqa: WPS111
 import uuid
+
+
+if _t.TYPE_CHECKING:  # pragma: no cover
+    import pathlib
+    from collections.abc import Callable
 
 import pytest
 
-from pylibsshext.sftp import SFTP_MAX_CHUNK
+from pylibsshext.sftp import SFTP, SFTP_MAX_CHUNK, _RemoteFile
 
 
 SMALL_PAYLOAD = 32
@@ -122,3 +131,26 @@ def test_put_existing(
     """Check that SFTP file upload works when target file exists."""
     sftp_session.put(str(src_path), str(pre_existing_dst_path))
     assert pre_existing_dst_path.read_bytes() == transmit_payload
+
+
+@pytest.mark.parametrize(
+    'path_modifier',
+    (str, lambda path: str(path).encode('utf-8')),
+    ids=('str', 'bytes'),
+)
+def test_remote_file_cm(
+    sftp_session: SFTP,
+    dst_path: pathlib.Path,
+    path_modifier: Callable[[pathlib.Path], str | bytes],
+) -> None:
+    """Test the ``_RemoteFile`` context manager works with both :class:`str` and :class:`bytes`."""
+    assert not dst_path.exists()
+    formatted_path = path_modifier(dst_path)
+
+    with _RemoteFile(
+        sftp_obj=sftp_session,
+        path=formatted_path,
+        flags=os.O_WRONLY | os.O_CREAT,
+    ):
+        assert dst_path.exists()
+    assert dst_path.read_bytes() == b''


### PR DESCRIPTION
##### SUMMARY
This change refactors get and put methods to use shared code for managing lifetime of remote file descriptors, avoiding code duplication and improving memory handling. This obsoletes one of the changes (fd leaks from #862).

##### ISSUE TYPE
- Bugfix Pull Request
