### PR TITLE
manylinux: Use gitlab mirror to pull libssh

### DIFF
--- a/build-scripts/manylinux-container-image/install_libssh.sh
+++ b/build-scripts/manylinux-container-image/install_libssh.sh
@@ -80,7 +80,7 @@ export OPENSSL_ROOT_DIR="${PYCA_OPENSSL_PATH}"
 git clone \
     --depth=1 \
     -b "${LIB_NAME}-${LIB_VERSION}" \
-    https://git.libssh.org/projects/${LIB_NAME}.git \
+    https://gitlab.com/${LIB_NAME}/${LIB_NAME}-mirror.git \
     "${LIB_CLONE_DIR}"
 
 source activate-userspace-tools.sh


### PR DESCRIPTION
##### SUMMARY

The main git server is currently under unbearable load of AI scrappers so offloading the work to our gitlab mirror should get more reliable and predictable results.

##### ISSUE TYPE
- Infrastructure Pull Request