### PR TITLE
Use a different manylinux image build job timeout based on arch

### DIFF
--- a/.github/workflows/build-manylinux-container-images.yml
+++ b/.github/workflows/build-manylinux-container-images.yml
@@ -22,7 +22,14 @@ jobs:
   build:
     runs-on: ${{ matrix.IMAGE.HOST_OS || 'ubuntu-latest' }}
 
-    timeout-minutes: 50
+    timeout-minutes: >-
+      ${{
+        case(
+          matrix.IMAGE.ARCH == 'ppc64le', 60,
+          matrix.IMAGE.ARCH == 's390x', 50,
+          8,
+        )
+      }}
 
     strategy:
       matrix:


### PR DESCRIPTION
##### SUMMARY
The ppc64le becomes even slower, but bumping all the timeouts for jobs that takes few minutes sounds wasteful. This tries to adjust timeout based on the architecture.

##### ISSUE TYPE
- Infrastructure Pull Request