### PR TITLE
sftp: Restrict remote path arguments of get()/put() to str

### DIFF
--- a/docs/changelog-fragments/885.breaking.rst
+++ b/docs/changelog-fragments/885.breaking.rst
@@ -1,0 +1,6 @@
+Changed the ``SFTP.get()`` and ``SFTP.put()`` API to accept only
+:class:`str` type for remote paths.
+
+Previously, this API used to accept also raw :class:`bytes` type, which
+required something on the way to guess the real encoding. Anything else
+than :class:`str` now raises :exc:`TypeError` -- by :user:`Jakuje`.

--- a/src/pylibsshext/sftp.pyx
+++ b/src/pylibsshext/sftp.pyx
@@ -15,6 +15,12 @@
 # License along with this library; if not, see file LICENSE.rst in this
 # repository.
 
+import typing as _t  # noqa: WPS111
+
+
+if _t.TYPE_CHECKING:  # pragma: no cover
+    import os
+
 from posix.fcntl cimport O_CREAT, O_RDONLY, O_TRUNC, O_WRONLY
 
 from cpython.mem cimport PyMem_Free, PyMem_Malloc
@@ -59,15 +65,13 @@ cdef class SFTP:
             sftp.sftp_free(self._libssh_sftp_session)
             self._libssh_sftp_session = NULL
 
-    def put(self, local_file, remote_file):
+    def put(self, local_file: str | os.PathLike[str], remote_file: str) -> None:
         """
         Upload local file to remote server.
 
         :param local_file: The file name on the local file system to upload
-        :type local_file: str or os.PathLike
 
         :param remote_file: The path to upload the file on the remote system
-        :type remote_file: str or bytes
         """
         cdef sftp.sftp_file rf
         cdef const char* c_buf
@@ -108,24 +112,19 @@ cdef class SFTP:
                 read_buffer = f.read(SFTP_MAX_CHUNK)
             sftp.sftp_close(rf)
 
-    def get(self, remote_file, local_file):
+    def get(self, remote_file: str, local_file: str | os.PathLike[str]) -> None:
         """
         Download remote file to local path.
 
         :param remote_file: The file path on the remote system to download
-        :type remote_file: str or bytes
 
         :param local_file: The path on the local file system to place the downloaded file
-        :type local_file: str or os.PathLike
         """
         cdef sftp.sftp_file rf
         cdef char *read_buffer = NULL
         cdef sftp.sftp_attributes attrs
 
-        remote_file_b = remote_file
-        if isinstance(remote_file_b, unicode):
-            remote_file_b = remote_file.encode("utf-8")
-
+        remote_file_b = remote_file.encode("utf-8")
         attrs = sftp.sftp_stat(self._libssh_sftp_session, remote_file_b)
         if attrs is NULL:
             raise LibsshSFTPException(

--- a/tests/unit/sftp_test.py
+++ b/tests/unit/sftp_test.py
@@ -1,11 +1,12 @@
 """Tests suite for sftp."""
 
+import pathlib
 import random
 import uuid
 
 import pytest
 
-from pylibsshext.sftp import SFTP_MAX_CHUNK
+from pylibsshext.sftp import SFTP, SFTP_MAX_CHUNK
 
 
 SMALL_PAYLOAD = 32
@@ -122,3 +123,43 @@ def test_put_existing(
     """Check that SFTP file upload works when target file exists."""
     sftp_session.put(str(src_path), str(pre_existing_dst_path))
     assert pre_existing_dst_path.read_bytes() == transmit_payload
+
+
+@pytest.fixture
+def bogus_src_path(tmp_path: pathlib.Path) -> pathlib.Path:
+    """Return a bogus source path that does not exist."""
+    return tmp_path / 'bogus-dst-file.txt'
+
+
+@pytest.fixture
+def bogus_dst_path(tmp_path: pathlib.Path) -> pathlib.Path:
+    """Return bogus destination path that does not exist."""
+    return tmp_path / 'bogus-src-file.txt'
+
+
+def test_put_bytes(
+    bogus_dst_path: pathlib.Path,
+    bogus_src_path: pathlib.Path,
+    sftp_session: SFTP,
+) -> None:
+    """Check that SFTP put() API does not accept :class:`bytes` as remote file path."""
+    error_msg = r"^Argument 'remote_file' has incorrect type \(expected str, got bytes\)$"
+    with pytest.raises(TypeError, match=error_msg):
+        sftp_session.put(
+            str(bogus_src_path),
+            str(bogus_dst_path).encode('utf-8'),
+        )
+
+
+def test_get_bytes(
+    bogus_dst_path: pathlib.Path,
+    bogus_src_path: pathlib.Path,
+    sftp_session: SFTP,
+) -> None:
+    """Check that SFTP ``get()`` API does not accept :class:`bytes` as remote file path."""
+    error_msg = r"^Argument 'remote_file' has incorrect type \(expected str, got bytes\)$"
+    with pytest.raises(TypeError, match=error_msg):
+        sftp_session.get(
+            str(bogus_src_path).encode('utf-8'),
+            str(bogus_dst_path),
+        )

--- a/tests/unit/sftp_test.py
+++ b/tests/unit/sftp_test.py
@@ -1,8 +1,16 @@
 """Tests suite for sftp."""
 
+# The Callable[[pathlib.Path], str | bytes] syntax is not supported natively by Python 3.9
+from __future__ import annotations
+
 import pathlib
 import random
+import typing as _t  # noqa: WPS111
 import uuid
+
+
+if _t.TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Callable
 
 import pytest
 
@@ -86,20 +94,44 @@ def pre_existing_dst_path(dst_path, other_payload):
     return dst_path
 
 
+@pytest.fixture(
+    ids=repr,
+    params=(
+        str,
+        pathlib.Path,
+    ),
+)
+def normalize_path(request) -> Callable[[pathlib.Path], _t.T | str]:
+    """Convert provided path either to str or Path."""
+    return request.param
+
+
 def test_make_sftp(sftp_session):
     """Smoke-test SFTP instance creation."""
     assert sftp_session
 
 
-def test_put(dst_path, src_path, sftp_session, transmit_payload):
+def test_put(
+    normalize_path: Callable[[pathlib.Path], _t.T | str],
+    dst_path: pathlib.Path,
+    src_path: pathlib.Path,
+    sftp_session: SFTP,
+    transmit_payload: bytes,
+) -> None:
     """Check that SFTP file transfer works."""
-    sftp_session.put(str(src_path), str(dst_path))
+    sftp_session.put(normalize_path(src_path), str(dst_path))
     assert dst_path.read_bytes() == transmit_payload
 
 
-def test_get(dst_path, src_path, sftp_session, transmit_payload):
+def test_get(
+    normalize_path: Callable[[pathlib.Path], _t.T | str],
+    dst_path: pathlib.Path,
+    src_path: pathlib.Path,
+    sftp_session: SFTP,
+    transmit_payload: bytes,
+) -> None:
     """Check that SFTP file download works."""
-    sftp_session.get(str(src_path), str(dst_path))
+    sftp_session.get(str(src_path), normalize_path(dst_path))
     assert dst_path.read_bytes() == transmit_payload
 
 


### PR DESCRIPTION
##### SUMMARY
Previously, this API used to accept also raw `bytes` type, which
required something on the way to guess the real encoding. Anything else
than `str` now raises `TypeError`.

##### ISSUE TYPE
- Bugfix Pull Request
